### PR TITLE
Fix cl-return error in claudemacs-repl-send-region

### DIFF
--- a/claudemacs-repl.el
+++ b/claudemacs-repl.el
@@ -361,42 +361,43 @@ If DIRECTORY is nil, use current `default-directory'."
   (let
       ((target-dir (or directory default-directory))
        (matching-buffer nil))
-    (dolist (buf (buffer-list))
-      (let
-          ((name (buffer-name buf))
-           (default-dir
-             (with-current-buffer buf
-               (when (boundp 'default-directory)
-                 default-directory)))
-           (eat-mode
-            (with-current-buffer buf
-              (and (boundp 'eat-mode) eat-mode))))
-        (when
-            (and (buffer-live-p buf)
-                 name     ; Ensure name is not nil
-                 ;; Check for directory-specific claudemacs buffer
-                 (or
-                  (and
-                   (string-match-p "^\\*claudemacs:" name)
-                   (string-prefix-p (concat "*claudemacs:" target-dir) name))
-                  ;; Fallback to generic buffers only if they match directory
-                  (and
+    (cl-block search-buffers
+      (dolist (buf (buffer-list))
+        (let
+            ((name (buffer-name buf))
+             (default-dir
+               (with-current-buffer buf
+                 (when (boundp 'default-directory)
+                   default-directory)))
+             (eat-mode
+              (with-current-buffer buf
+                (and (boundp 'eat-mode) eat-mode))))
+          (when
+              (and (buffer-live-p buf)
+                   name     ; Ensure name is not nil
+                   ;; Check for directory-specific claudemacs buffer
                    (or
-                    (string= name "*claude*")
-                    (string= name "*claudemacs*"))
-                   (when default-dir
-                     (string=
-                      (file-truename default-dir)
-                      (file-truename target-dir))))
-                  ;; Check for eat-mode buffers with claude in name
-                  (and eat-mode
-                       (string-match-p "claude" name)
-                       (when default-dir
-                         (string=
-                          (file-truename default-dir)
-                          (file-truename target-dir))))))
-          (setq matching-buffer buf)
-          (cl-return))))
+                    (and
+                     (string-match-p "^\\*claudemacs:" name)
+                     (string-prefix-p (concat "*claudemacs:" target-dir) name))
+                    ;; Fallback to generic buffers only if they match directory
+                    (and
+                     (or
+                      (string= name "*claude*")
+                      (string= name "*claudemacs*"))
+                     (when default-dir
+                       (string=
+                        (file-truename default-dir)
+                        (file-truename target-dir))))
+                    ;; Check for eat-mode buffers with claude in name
+                    (and eat-mode
+                         (string-match-p "claude" name)
+                         (when default-dir
+                           (string=
+                            (file-truename default-dir)
+                            (file-truename target-dir))))))
+            (setq matching-buffer buf)
+            (cl-return-from search-buffers)))))
     matching-buffer))
 
 (defun claudemacs-repl--buffer-matches-directory (buffer target-dir)

--- a/claudemacs-repl.el
+++ b/claudemacs-repl.el
@@ -366,9 +366,9 @@ If DIRECTORY is nil, use current `default-directory'."
         (let
             ((name (buffer-name buf))
              (default-dir
-               (with-current-buffer buf
-                 (when (boundp 'default-directory)
-                   default-directory)))
+              (with-current-buffer buf
+                (when (boundp 'default-directory)
+                  default-directory)))
              (eat-mode
               (with-current-buffer buf
                 (and (boundp 'eat-mode) eat-mode))))


### PR DESCRIPTION
## Summary

- Fix "No catch for tag: --cl-block-nil--" error when calling `claudemacs-repl-send-region`
- Replace problematic `cl-return` usage in `dolist` loop with proper `cl-block` structure
- Resolves byte-compilation warnings and runtime errors

## Problem

The function `claudemacs-repl--get-buffer-for-directory` used `cl-return` within a `dolist` loop, but `dolist` doesn't create a `cl-block` context. This caused a runtime error:

```
claudemacs-repl--get-buffer-for-directory: No catch for tag: --cl-block-nil--, nil
```

## Solution

- Wrap the `dolist` in an explicit `cl-block 'search-buffers'`
- Replace `cl-return` with `cl-return-from search-buffers`
- This provides proper early termination from the loop when a matching buffer is found

## Test plan

- [x] Code compiles without warnings using `emacs --batch -f batch-byte-compile`
- [x] Manual testing shows `claudemacs-repl-send-region` now works without errors
- [x] Verified fix works with both GitHub-installed and local development versions

🤖 Generated with [Claude Code](https://claude.ai/code)