### PR TITLE
chore(refactor): Phase 0 - docstring/header normalization (ASCII quoting)

### DIFF
--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -1608,8 +1608,8 @@ This function has the side effect of modifying global variables:
   (enkan-repl--ws-set-project-aliases nil))
 
 (defun enkan-repl--disable-global-minor-mode-if-active ()
-  "Disable `enkan-repl-global-minor-mode` if it is active.
-This function has the side effect of calling `enkan-repl-global-minor-mode`.
+  "Disable `enkan-repl-global-minor-mode' if it is active.
+This function has the side effect of calling `enkan-repl-global-minor-mode'.
 Returns t if mode was disabled, nil otherwise."
   (when enkan-repl-global-minor-mode
     (enkan-repl-global-minor-mode -1)


### PR DESCRIPTION
Purpose

- Normalize autoload cookies: keep them only on public, interactive commands.
- Remove autoload cookies from private helpers (double-dash names).
- Add missing autoload on `enkan-repl-open-center-file`.

Scope

- Mechanical change only; no behavior changes.
- Touched: enkan-repl.el (comments/metadata lines only).

Acceptance Criteria

- CI green (`make check`) on Emacs 30.1.
- Byte-compile/package-lint warnings do not increase.
- Diff small (<= 10 LOC).

Risk / Rollback

- Very low; revert is trivial.

Next

- Phase 0 continues with docstring/header normalization where needed.

Notes

- Refactoring roadmap drafted locally at docs/refactoring-plan-2025-09.md (currently gitignored).
