### PR TITLE
fix: Phase 0 - header metadata alignment (hmenu, mac-notify)

### DIFF
--- a/enkan-repl-mac-notify.el
+++ b/enkan-repl-mac-notify.el
@@ -5,7 +5,7 @@
 ;; Author: phasetr <phasetr@gmail.com>
 ;; Version: 0.9.0
 ;; Package-Requires: ((emacs "28.2"))
-;; Keywords: enkan ai tools convenience macos notification sound
+;; Keywords: enkan ai tools convenience macos notification sound utilities
 ;; URL: https://github.com/phasetr/enkan-repl
 ;; License: MIT
 

--- a/hmenu.el
+++ b/hmenu.el
@@ -5,6 +5,7 @@
 ;; Author: phasetr <phasetr@gmail.com>
 ;; Keywords: convenience, interface
 ;; Version: 1.0.0
+;; URL: https://github.com/phasetr/enkan-repl
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Summary

- Phase 0 (safety net): align header metadata only; no behavior change.
- Files: hmenu.el (add URL), enkan-repl-mac-notify.el (keywords tweak).

Verification

- make check: all tests pass; compile/checkdoc/package-lint clean.

Notes

- Kept diffs minimal and cohesive to avoid PR sprawl.
