### PR TITLE
refactor: extract workspace naming utils (Phase 2)

### DIFF
--- a/enkan-repl-workspace.el
+++ b/enkan-repl-workspace.el
@@ -1,0 +1,77 @@
+;;; enkan-repl-workspace.el --- Workspace management utilities for enkan-repl -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 [phasetr]
+
+;; Author: phasetr <phasetr@gmail.com>
+;; URL: https://github.com/phasetr/enkan-repl
+;; Keywords: tools
+;; Package-Requires: ((emacs "28.2") (cl-lib "0.5"))
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Workspace management utilities for enkan-repl package.
+;; This file provides pure functions for workspace state management,
+;; ID generation, and workspace manipulation.
+
+;;; Code:
+
+(require 'cl-lib)
+
+;;;; Workspace Management Pure Functions
+
+(defun enkan-repl--generate-next-workspace-id (workspaces)
+  "Generate next workspace ID from WORKSPACES alist.
+Returns zero-padded numeric string (e.g., \"01\", \"02\")."
+  (if (null workspaces)
+      "01"
+    (let ((ids (mapcar (lambda (ws)
+                         (string-to-number (car ws)))
+                       workspaces)))
+      (format "%02d" (1+ (apply #'max ids))))))
+
+(defun enkan-repl--create-workspace-state (workspaces)
+  "Create new workspace and return its ID.
+WORKSPACES is the current workspace alist.
+Returns the new workspace ID string."
+  (enkan-repl--generate-next-workspace-id workspaces))
+
+(defun enkan-repl--add-workspace (workspaces new-id)
+  "Add new workspace with NEW-ID to WORKSPACES alist.
+Returns updated alist with new workspace."
+  (cons (cons new-id
+              (list :current-project nil
+                    :session-list nil
+                    :session-counter 0
+                    :project-aliases nil))
+        workspaces))
+
+(defun enkan-repl--get-workspace-state (workspaces workspace-id)
+  "Get state plist for WORKSPACE-ID from WORKSPACES alist.
+Returns plist or nil if not found."
+  (cdr (assoc workspace-id workspaces #'string=)))
+
+(defun enkan-repl--can-delete-workspace (workspace-id workspaces)
+  "Check if WORKSPACE-ID can be deleted from WORKSPACES.
+Cannot delete if it's the only workspace or doesn't exist."
+  (and (> (length workspaces) 1)
+       (assoc workspace-id workspaces #'string=)
+       t))
+
+(defun enkan-repl--delete-workspace (workspaces workspace-id)
+  "Remove WORKSPACE-ID from WORKSPACES alist.
+Returns updated alist without the specified workspace."
+  (cl-remove-if (lambda (ws)
+                  (string= (car ws) workspace-id))
+                workspaces))
+
+(defun enkan-repl--list-workspace-ids (workspaces)
+  "List all workspace IDs from WORKSPACES alist.
+Returns sorted list of unique ID strings."
+  (when workspaces
+    (let ((ids (mapcar #'car workspaces)))
+      (sort (cl-remove-duplicates ids :test #'string=) #'string<))))
+
+(provide 'enkan-repl-workspace)
+;;; enkan-repl-workspace.el ends here

--- a/test/enkan-repl-workspace-test.el
+++ b/test/enkan-repl-workspace-test.el
@@ -1,0 +1,115 @@
+;;; enkan-repl-workspace-test.el --- Tests for workspace utilities -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Test suite for enkan-repl-workspace.el pure functions
+
+;;; Code:
+
+(require 'ert)
+(require 'enkan-repl-workspace)
+
+(ert-deftest test-enkan-repl--generate-next-workspace-id ()
+  "Test workspace ID generation."
+  ;; Test with nil workspaces
+  (should (string= "01" (enkan-repl--generate-next-workspace-id nil)))
+  
+  ;; Test with empty list
+  (should (string= "01" (enkan-repl--generate-next-workspace-id '())))
+  
+  ;; Test with single workspace
+  (should (string= "02" (enkan-repl--generate-next-workspace-id '(("01" . nil)))))
+  
+  ;; Test with multiple workspaces
+  (should (string= "04" (enkan-repl--generate-next-workspace-id
+                         '(("01" . nil) ("02" . nil) ("03" . nil)))))
+  
+  ;; Test with non-sequential IDs
+  (should (string= "06" (enkan-repl--generate-next-workspace-id
+                         '(("01" . nil) ("03" . nil) ("05" . nil))))))
+
+(ert-deftest test-enkan-repl--add-workspace ()
+  "Test adding workspace to alist."
+  (let ((workspaces '()))
+    ;; Add to empty list
+    (setq workspaces (enkan-repl--add-workspace workspaces "01"))
+    (should (equal 1 (length workspaces)))
+    (should (assoc "01" workspaces))
+    (let ((state (cdr (assoc "01" workspaces))))
+      (should (plist-member state :current-project))
+      (should (equal nil (plist-get state :current-project))))
+    
+    ;; Add another workspace
+    (setq workspaces (enkan-repl--add-workspace workspaces "02"))
+    (should (equal 2 (length workspaces)))
+    (should (assoc "02" workspaces))))
+
+(ert-deftest test-enkan-repl--get-workspace-state ()
+  "Test retrieving workspace state."
+  (let ((workspaces '(("01" :current-project "project1"
+                            :session-list ("session1")
+                            :session-counter 1
+                            :project-aliases nil)
+                      ("02" :current-project nil
+                            :session-list nil
+                            :session-counter 0
+                            :project-aliases nil))))
+    ;; Get existing workspace
+    (should (equal '(:current-project "project1"
+                     :session-list ("session1")
+                     :session-counter 1
+                     :project-aliases nil)
+                   (enkan-repl--get-workspace-state workspaces "01")))
+    
+    ;; Get non-existing workspace
+    (should (null (enkan-repl--get-workspace-state workspaces "03")))))
+
+(ert-deftest test-enkan-repl--can-delete-workspace ()
+  "Test workspace deletion validation."
+  (let ((workspaces '(("01" . nil) ("02" . nil))))
+    ;; Can delete when multiple workspaces exist
+    (should (enkan-repl--can-delete-workspace "01" workspaces))
+    (should (enkan-repl--can-delete-workspace "02" workspaces))
+    
+    ;; Cannot delete non-existing workspace
+    (should-not (enkan-repl--can-delete-workspace "03" workspaces))
+    
+    ;; Cannot delete when only one workspace
+    (let ((single-ws '(("01" . nil))))
+      (should-not (enkan-repl--can-delete-workspace "01" single-ws)))))
+
+(ert-deftest test-enkan-repl--delete-workspace ()
+  "Test workspace deletion."
+  (let ((workspaces '(("01" . nil) ("02" . nil) ("03" . nil))))
+    ;; Delete middle workspace
+    (setq workspaces (enkan-repl--delete-workspace workspaces "02"))
+    (should (equal 2 (length workspaces)))
+    (should-not (assoc "02" workspaces))
+    (should (assoc "01" workspaces))
+    (should (assoc "03" workspaces))
+    
+    ;; Delete first workspace
+    (setq workspaces (enkan-repl--delete-workspace workspaces "01"))
+    (should (equal 1 (length workspaces)))
+    (should-not (assoc "01" workspaces))
+    (should (assoc "03" workspaces))))
+
+(ert-deftest test-enkan-repl--list-workspace-ids ()
+  "Test listing workspace IDs."
+  ;; Test with nil
+  (should (null (enkan-repl--list-workspace-ids nil)))
+  
+  ;; Test with empty list
+  (should (null (enkan-repl--list-workspace-ids '())))
+  
+  ;; Test with workspaces in order
+  (should (equal '("01" "02" "03")
+                 (enkan-repl--list-workspace-ids
+                  '(("01" . nil) ("02" . nil) ("03" . nil)))))
+  
+  ;; Test with workspaces out of order
+  (should (equal '("01" "02" "03")
+                 (enkan-repl--list-workspace-ids
+                  '(("03" . nil) ("01" . nil) ("02" . nil))))))
+
+(provide 'enkan-repl-workspace-test)
+;;; enkan-repl-workspace-test.el ends here


### PR DESCRIPTION
## 目的
フェーズ2: ワークスペース/バッファ命名の純関数群を専用モジュールへ移動

## 作業内容
- ワークスペース関連の純関数を `enkan-repl-workspace.el` へ抽出（移動のみ）
- 既存呼び出しを置換（関数本体は移動のみ、ロジック不変）
- 最低限の ERT テスト追加（純関数の入出力テスト）

## 変更範囲
- 新規ファイル: `enkan-repl-workspace.el`（予定）
- 変更ファイル: `enkan-repl.el`（関数移動）
- 新規テスト: `test/enkan-repl-workspace-test.el`（予定）

## 手段
- 純関数の機械的移動
- 呼び出し先の書き換え
- ロジック変更なし

## 受け入れ基準
- [ ] `make check` 緑
- [ ] Byte-compile 警告増なし
- [ ] 差分 <= 300行
- [ ] 振る舞い不変

## リスクとロールバック
- リスク: 関数移動による参照エラーの可能性
- ロールバック: `git revert` で安全に戻せる粒度

## テスト観点
- 純関数の入出力テスト（新規追加予定）
- 既存テストの全てパス

## 進捗
現在空コミットでPRを作成。実装はこれから順次進めます。

## 参照
- リファクタリング計画: `docs/refactoring-plan-2025-09.md`
- フェーズ2第6項目

🤖 Generated with [Claude Code](https://claude.ai/code)