### PR TITLE
fix: fallback to get-buffer-process when eat--process is unbound

### DIFF
--- a/enkan-repl-utils.el
+++ b/enkan-repl-utils.el
@@ -68,7 +68,10 @@ Returns workspace ID string (e.g., \"01\") or nil if not an enkan buffer."
 
 (defun enkan-repl--get-workspace-buffer-count-pure (buffer-list workspace-id)
   "Pure function to count living eat buffers for WORKSPACE-ID in BUFFER-LIST.
-Returns the number of valid enkan buffers with active eat processes that belong to the workspace."
+Returns the number of valid enkan buffers with active eat processes that belong to the workspace.
+Falls back to `get-buffer-process' when `eat--process' is unbound or nil,
+which can happen if the buffer-local variable was reset while the OS process
+remained attached to the buffer."
   (let ((count 0))
     (dolist (buffer buffer-list)
       (when (and (bufferp buffer)
@@ -76,9 +79,9 @@ Returns the number of valid enkan buffers with active eat processes that belong 
                  (enkan-repl--buffer-name-matches-workspace
                   (buffer-name buffer) workspace-id)
                  (with-current-buffer buffer
-                   (and (boundp 'eat--process)
-                        eat--process
-                        (process-live-p eat--process))))
+                   (let ((proc (or (and (boundp 'eat--process) eat--process)
+                                   (get-buffer-process buffer))))
+                     (and proc (process-live-p proc)))))
         (setq count (1+ count))))
     count))
 

--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -1626,7 +1626,10 @@ Returns plist with :buffer, :name, :live-p, :has-process, :process."
   "Pure function to get available enkan buffers from BUFFER-LIST.
 Consolidates buffer collection and filtering into single function.
 Returns list of valid enkan buffers with active eat processes.
-Only returns buffers that belong to the current workspace."
+Only returns buffers that belong to the current workspace.
+Falls back to `get-buffer-process' when `eat--process' is unbound or nil,
+which can happen if the buffer-local variable was reset while the OS process
+remained attached to the buffer."
   (let ((current-ws enkan-repl--current-workspace))
     (seq-filter (lambda (buffer)
                   (and (bufferp buffer)
@@ -1635,9 +1638,9 @@ Only returns buffers that belong to the current workspace."
                        (enkan-repl--buffer-name-matches-workspace
                         (buffer-name buffer) current-ws)
                        (with-current-buffer buffer
-                         (and (boundp 'eat--process)
-                              eat--process
-                              (process-live-p eat--process)))))
+                         (let ((proc (or (and (boundp 'eat--process) eat--process)
+                                         (get-buffer-process buffer))))
+                           (and proc (process-live-p proc))))))
                 buffer-list)))
 
 (defun enkan-repl--resolve-target-buffer (pfx alias buffers)


### PR DESCRIPTION
## Summary
- C-M-l (`enkan-repl-setup-current-project-layout`) reported "0 actual sessions" even when eat sessions were running and interactive
- Root cause: `enkan-repl--get-workspace-buffer-count-pure` and `enkan-repl--get-available-buffers` only checked the buffer-local `eat--process` variable. In some states `eat--process` becomes unbound (void) while the OS process remains attached to the buffer
- Fix: fall back to `(get-buffer-process buffer)` when `eat--process` is unbound or nil

## Test plan
- [x] Existing `test-enkan-repl--get-workspace-buffer-count-pure` passes
- [x] Manual: with `eat--process` unbound and live process attached, C-M-l detects sessions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)