### PR TITLE
fix: widen eat pane in 1-session layout to fit heavy TUIs

### DIFF
--- a/examples/window-layouts.el
+++ b/examples/window-layouts.el
@@ -100,7 +100,7 @@ Returns cons (window . buffer-name) or nil if session not registered."
 Category: Utilities"
   (interactive)
   (delete-other-windows)
-  (split-window-right)
+  (split-window-right (floor (* (window-width) 0.35)))
   ;; Set window variables - direct assignment by position
   ;; Currently at rightmost window, go back to leftmost
   (setq enkan-repl--window-1 (selected-window))


### PR DESCRIPTION
## Summary
- The default 50/50 split in \`enkan-repl-setup-1session-layout\` left the eat pane too narrow for heavier TUI applications (e.g. claude code CLI), causing the TUI's renderer to lock up under repaints
- Adjusts \`split-window-right\` to allocate ~35% of the frame width to the center file pane (left), giving the eat pane (right) ~65%

## Test plan
- [x] Manual: 1-session layout with claude no longer freezes the eat buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)