### PR TITLE
feat: add manual tmux reattach commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,12 @@ format: ## Auto-format elisp files using built-in indent-region (spaces only)
 	$(BATCH) --eval "(progn (find-file \"enkan-repl.el\") (setq-local indent-tabs-mode nil) (untabify (point-min) (point-max)) (mark-whole-buffer) (indent-region (point-min) (point-max)) (save-buffer))"
 	$(BATCH) --eval "(progn (find-file \"test/enkan-repl-test.el\") (setq-local indent-tabs-mode nil) (untabify (point-min) (point-max)) (mark-whole-buffer) (indent-region (point-min) (point-max)) (save-buffer))"
 
-check: test compile checkdoc lint format ## Run all quality checks including formatting
+check: test compile checkdoc lint format clean ## Run all quality checks including formatting
 
-check-ci: test compile checkdoc format ## Run quality checks for CI (without package-lint)
+check-ci: test compile checkdoc format clean ## Run quality checks for CI (without package-lint)
 
 clean: ## Remove compiled files
-	rm -f *.elc
+	find . -path ./.git -prune -o -name '*.elc' -type f -exec rm -f {} +
 
 extract-api: ## Extract public API documentation as org file
 	$(BATCH) -l scripts/generate-docs.el --eval "(extract-public-api)"

--- a/README.org
+++ b/README.org
@@ -207,7 +207,7 @@ compatibility with other environments has not been verified.
    /This ensures Claude sessions are isolated and changes are tracked safely./
 
 3. *Open project file*: =M-x enkan-repl-open-project-input-file=
-4. *Start eat session*: =M-x enkan-repl-start-eat=
+4. *Start terminal session*: =M-x enkan-repl-start-session=
 5. *Write your thoughts* in the input org-mode file
 6. *Access functions easily*: Use =M-x enkan-repl-cheat-sheet= to browse and select functions
 7. *Send specific parts* using =M-x enkan-repl-send-region= or =M-x enkan-repl-send-rest-of-buffer=
@@ -258,12 +258,13 @@ Currently operates with a single fixed workspace (=ws:01=), with multi-workspace
 - =enkan-repl-send-5= - Send \\='5\\=' to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.
 
 *** Session Control
+- =enkan-repl-start-session= - Start a terminal session in the current directory. This is the backend-neutral session starter.  It works with both the eat and tmux terminal backends configured by `enkan-repl-terminal-backend'. FORCE is accepted for interactive compatibility and currently ignored; the command always starts a new session.
 - =enkan-repl-setup= - Arrange windows for (the author's) optimal workflow
 - =enkan-repl-workspace-delete= - Delete a workspace and stop all associated terminal resources. This is the only interactive workspace deletion command.  In `enkan-repl-workspace-list-mode', delete the workspace at point; otherwise delete the current workspace.  With prefix ARG, prompt for a workspace. Noninteractive string ARG deletes that workspace ID.  All paths use `enkan-repl--delete-workspace-completely'.
 
 *** Utilities
+- =enkan-repl-tmux-reattach= - Reconnect Emacs state to live tmux sessions. FILE defaults to `enkan-repl-state-file'.  Live tmux sessions whose names start with `enkan-repl-tmux-session-prefix' define the workspaces to restore.  When a matching persisted workspace exists, its saved state is reused.  When no saved state exists for a live tmux session, a minimal workspace is imported from the tmux session's windows so reattach works after Emacs state was lost.  This command is intentionally manual; enkan-repl does not reattach on load.
 - =enkan-repl-recenter-bottom= - Recenter all enkan terminal buffers at bottom.
-- =enkan-repl-start-eat= - 
 - =enkan-repl-toggle-global-mode= - Toggle enkan-repl global mode on/off.
 - =enkan-repl-workspace-switch= - Switch to another workspace. Uses `hmenu' if available to show workspace ID with its project.
 
@@ -298,22 +299,18 @@ same user-facing send / layout commands (=enkan-repl-send-line=,
   instances of the same project become =alias=, =alias-2=, =alias-3=,
   ... with the corresponding =*ws:NN enkan:/path/*<N>= mirror buffers
   inside Emacs.
-- A read-only mirror buffer is updated via =tmux capture-pane= so the
+- A read-only mirror buffer can be updated via =tmux capture-pane= so the
   layout / send-line code can find sessions via the usual
-  =buffer-list= mechanism.  Visible mirrors refresh every
-  =enkan-repl-tmux-mirror-interval= seconds (default =5.0=).  The
-  =capture-pane= process runs asynchronously so tmux capture itself does
-  not block Emacs's main thread.  Hidden mirrors do not run capture until
-  displayed or manually refreshed.
-  Timer refresh is also deferred while the minibuffer is active, so
-  completion UIs such as =consult-buffer= do not trigger mirror capture
-  just because they temporarily preview a mirror buffer.
+  =buffer-list= mechanism.  Mirror refresh is manual by default: displaying
+  or recreating a mirror buffer does not capture pane content.  Press =g= in a
+  mirror buffer, or run =M-x enkan-repl-tmux-refresh-current=, to refresh it.
+  Automatic timer refresh is opt-in via
+  =(setq enkan-repl-tmux-mirror-auto-refresh t)= and then uses
+  =enkan-repl-tmux-mirror-interval= seconds.
   Disable mirroring with =(setq enkan-repl-tmux-mirror nil)= if not
   desired.
 - Mirror buffers show refresh state in the header line
-  (=refreshing=, =hidden=, =fresh=, =unchanged=, =closed=).  Press =g=
-  in a mirror buffer, or run =M-x enkan-repl-tmux-refresh-current=, to
-  force an immediate refresh.
+  (=refreshing=, =hidden=, =fresh=, =unchanged=, =closed=).
 - Run =M-x enkan-repl-tmux-refresh-workspace= to recreate or force
   refresh all tmux mirror buffers for the currently selected workspace.
   This is useful when tmux windows exist but the Emacs-side mirrors are
@@ -327,15 +324,14 @@ same user-facing send / layout commands (=enkan-repl-send-line=,
 - Persistent state is stored at =enkan-repl-state-file=
   (=~/.emacs.d/enkan-repl-state.eld= by default).  enkan-repl does not
   automatically reconnect Emacs to live tmux sessions on startup.  Run
-  =M-x enkan-repl-tmux-reattach= when you want to manually reconcile the
-  saved workspace state with the live tmux server.  The reconciliation
-  policy is controlled by =enkan-repl-state-recovery-policy=
-  (=reattach= / =recreate= / =prompt= / =ignore=, default =reattach=).
-  In the default policy, only workspaces present in both the saved state
-  and the live tmux server are restored.  Reattach ensures mirror buffers
-  exist, but it avoids force-refreshing every restored workspace; use
-  =enkan-repl-tmux-refresh-workspace= when you explicitly want to refresh
-  the current workspace's mirror contents.
+  =M-x enkan-repl-tmux-reattach= when you want to manually reconnect.
+  Live =enkan-*= tmux sessions define the workspaces to restore.  When
+  saved state exists for a live workspace it is reused; when it does not,
+  enkan-repl imports a minimal workspace from the tmux windows so the
+  session can be used again.  Reattach ensures mirror buffers exist, but
+  it avoids force-refreshing every restored workspace; use
+  =M-x enkan-repl-tmux-refresh-workspace= when you explicitly want to
+  refresh the current workspace's mirror contents.
 
 **** eat backend specifics
 

--- a/README.org
+++ b/README.org
@@ -301,14 +301,23 @@ same user-facing send / layout commands (=enkan-repl-send-line=,
 - A read-only mirror buffer is updated via =tmux capture-pane= so the
   layout / send-line code can find sessions via the usual
   =buffer-list= mechanism.  Visible mirrors refresh every
-  =enkan-repl-tmux-mirror-interval= seconds (default =5.0=).  Hidden
-  mirrors do not run capture until displayed or manually refreshed.
+  =enkan-repl-tmux-mirror-interval= seconds (default =5.0=).  The
+  =capture-pane= process runs asynchronously so tmux capture itself does
+  not block Emacs's main thread.  Hidden mirrors do not run capture until
+  displayed or manually refreshed.
+  Timer refresh is also deferred while the minibuffer is active, so
+  completion UIs such as =consult-buffer= do not trigger mirror capture
+  just because they temporarily preview a mirror buffer.
   Disable mirroring with =(setq enkan-repl-tmux-mirror nil)= if not
   desired.
 - Mirror buffers show refresh state in the header line
   (=refreshing=, =hidden=, =fresh=, =unchanged=, =closed=).  Press =g=
   in a mirror buffer, or run =M-x enkan-repl-tmux-refresh-current=, to
   force an immediate refresh.
+- Run =M-x enkan-repl-tmux-refresh-workspace= to recreate or force
+  refresh all tmux mirror buffers for the currently selected workspace.
+  This is useful when tmux windows exist but the Emacs-side mirrors are
+  stale or missing.
 - =M-x enkan-repl-tmux-attach= launches an external terminal app and
   attaches to the current workspace's tmux session.  The attach
   command is configurable via =enkan-repl-tmux-attach-command= (a
@@ -316,10 +325,17 @@ same user-facing send / layout commands (=enkan-repl-send-line=,
 - =M-x enkan-repl-tmux-kill-session= kills a single =enkan-*= session;
   =M-x enkan-repl-tmux-kill-all-enkan= confirms then kills all of them.
 - Persistent state is stored at =enkan-repl-state-file=
-  (=~/.emacs.d/enkan-repl-state.eld= by default).  On Emacs restart the
-  state is reconciled with the live tmux server according to
-  =enkan-repl-state-recovery-policy= (=reattach= / =recreate= /
-  =prompt= / =ignore=, default =reattach=).
+  (=~/.emacs.d/enkan-repl-state.eld= by default).  enkan-repl does not
+  automatically reconnect Emacs to live tmux sessions on startup.  Run
+  =M-x enkan-repl-tmux-reattach= when you want to manually reconcile the
+  saved workspace state with the live tmux server.  The reconciliation
+  policy is controlled by =enkan-repl-state-recovery-policy=
+  (=reattach= / =recreate= / =prompt= / =ignore=, default =reattach=).
+  In the default policy, only workspaces present in both the saved state
+  and the live tmux server are restored.  Reattach ensures mirror buffers
+  exist, but it avoids force-refreshing every restored workspace; use
+  =enkan-repl-tmux-refresh-workspace= when you explicitly want to refresh
+  the current workspace's mirror contents.
 
 **** eat backend specifics
 

--- a/enkan-repl-constants.el
+++ b/enkan-repl-constants.el
@@ -11,7 +11,8 @@
 ;;; Code:
 
 (defconst enkan-repl-cheat-sheet-candidates
-  '(("enkan-repl-send-region" . "Send region text (from START to END) to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
+  '(("enkan-repl-tmux-reattach" . "Reconnect Emacs state to live tmux sessions. FILE defaults to `enkan-repl-state-file'.  Live tmux sessions whose names start with `enkan-repl-tmux-session-prefix' define the workspaces to restore.  When a matching persisted workspace exists, its saved state is reused.  When no saved state exists for a live tmux session, a minimal workspace is imported from the tmux session's windows so reattach works after Emacs state was lost.  This command is intentionally manual; enkan-repl does not reattach on load.")
+    ("enkan-repl-send-region" . "Send region text (from START to END) to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-send-line" . "Send current line to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-send-enter" . "Send enter key to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-send-1" . "Send \\\\='1\\\\=' to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
@@ -21,11 +22,11 @@
     ("enkan-repl-send-5" . "Send \\\\='5\\\\=' to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-recenter-bottom" . "Recenter all enkan terminal buffers at bottom.  Category: Utilities")
     ("enkan-repl-open-project-input-file" . "Open or create project input file for DIRECTORY. If DIRECTORY is nil, use current `default-directory'. If project input file exists, open it directly. If not exists, create from template then open.  Category: Utilities")
-    ("enkan-repl-start-eat" . "")
-    ("enkan-repl-setup" . "Set up window layout based on context. - Standard input file: basic window layout with project input file on left and eat session on right in current workspace - Center file: auto start eat sessions using project configuration in current workspace  Category: Session Controller")
+    ("enkan-repl-start-session" . "Start a terminal session in the current directory. This is the backend-neutral session starter.  It works with both the eat and tmux terminal backends configured by `enkan-repl-terminal-backend'. FORCE is accepted for interactive compatibility and currently ignored; the command always starts a new session.  Category: Session Controller")
+    ("enkan-repl-setup" . "Set up window layout based on context. - Standard input file: basic window layout with project input file on left and terminal session on right in current workspace - Center file: auto start terminal sessions using project configuration in current workspace  Category: Session Controller")
     ("enkan-repl-cheat-sheet" . "Display interactive `cheat-sheet' for enkan-repl commands.  Category: Command Palette")
     ("enkan-repl-toggle-global-mode" . "Toggle enkan-repl global mode on/off.")
-    ("enkan-repl-send-escape" . "Send ESC key to eat session buffer with optional PFX. - If called from enkan buffer: Send ESC to current buffer - If called from center file without prefix: Select from available enkan buffers - With numeric prefix: Send to buffer at that index (1-based)  Category: Center File Multi-buffer Access")
+    ("enkan-repl-send-escape" . "Send ESC key to enkan session buffer with optional PFX. - If called from enkan buffer: Send ESC to current buffer - If called from center file without prefix: Select from available enkan buffers - With numeric prefix: Send to buffer at that index (1-based)  Category: Center File Multi-buffer Access")
     ("enkan-repl-open-project-directory" . "Open project directory in Dired from enkan-repl-projects with optional PFX. With prefix argument (\\\\[universal-argument]), select from available buffers.  Category: Center File Multi-buffer Access")
     ("enkan-repl-open-center-file" . "Open or create the center file based on enkan-repl-center-file configuration.  Category: Center File Operations")
     ("enkan-repl-print-setup-to-buffer" . "Print current setup variables for debugging. Displays enkan-repl-projects, enkan-repl-target-directories, enkan-repl-project-aliases, and current session state.  Category: Debugging")
@@ -35,7 +36,7 @@
 Each element is a cons cell (FUNCTION-NAME . DESCRIPTION).")
 
 (defconst enkan-repl-cheat-sheet-function-count
-  20
+  21
   "Number of functions in cheat-sheet.")
 
 (provide 'enkan-repl-constants)

--- a/enkan-repl-state.el
+++ b/enkan-repl-state.el
@@ -203,7 +203,8 @@ Behavior is governed by `enkan-repl-state-recovery-policy':
 - `ignore'  : do nothing.
 
 Returns a plist describing the reconciliation result:
-  (:loaded-workspaces ALIST :restored IDS :dropped IDS :orphan-tmux SESSIONS)."
+  (:loaded-workspaces ALIST :restored IDS :dropped IDS :orphan-tmux SESSIONS
+   :current CURRENT)."
   (interactive)
   (let ((payload (enkan-repl-state-load file)))
     (when (and payload (not (eq enkan-repl-state-recovery-policy 'ignore)))
@@ -231,7 +232,8 @@ Returns a plist describing the reconciliation result:
           (list :loaded-workspaces restored
                 :restored keep-ids
                 :dropped dropped
-                :orphan-tmux tmux-only))))))
+                :orphan-tmux tmux-only
+                :current (plist-get payload :current)))))))
 
 (provide 'enkan-repl-state)
 ;;; enkan-repl-state.el ends here

--- a/enkan-repl-terminal.el
+++ b/enkan-repl-terminal.el
@@ -434,6 +434,9 @@ Applies to every active tmux mirror buffer."
 (defvar-local enkan-repl--tmux-mirror-timer nil
   "Buffer-local: idle timer driving capture-pane refreshes.")
 
+(defvar-local enkan-repl--tmux-mirror-refresh-process nil
+  "Buffer-local asynchronous `tmux capture-pane' process.")
+
 (defvar-local enkan-repl--tmux-mirror-state 'idle
   "Buffer-local refresh state for the tmux mirror buffer.")
 
@@ -613,6 +616,75 @@ LINES is the maximum scrollback to include (negative numbers per
        t)
       ""))
 
+(defun enkan-repl--terminal-tmux--capture-pane-async (id lines callback)
+  "Capture tmux ID asynchronously and call CALLBACK with content and status.
+LINES is the maximum scrollback to include.  CALLBACK receives two
+arguments: CONTENT, or nil on failure, and the tmux process exit status."
+  (unless (executable-find enkan-repl-tmux-executable)
+    (user-error "Tmux executable not found: %s" enkan-repl-tmux-executable))
+  (let* ((capture-buffer (generate-new-buffer " *enkan-repl tmux async capture*"))
+         (command (list enkan-repl-tmux-executable
+                        "capture-pane" "-p" "-J" "-S"
+                        (format "-%d" (max 0 lines))
+                        "-t" id)))
+    (make-process
+     :name (format "enkan-tmux-capture %s" id)
+     :buffer capture-buffer
+     :command command
+     :connection-type 'pipe
+     :noquery t
+     :sentinel
+     (lambda (process _event)
+       (when (memq (process-status process) '(exit signal))
+         (let ((status (process-exit-status process))
+               (content (when (buffer-live-p capture-buffer)
+                          (with-current-buffer capture-buffer
+                            (buffer-substring-no-properties
+                             (point-min) (point-max))))))
+           (when (buffer-live-p capture-buffer)
+             (kill-buffer capture-buffer))
+           (funcall callback
+                    (and (zerop status) content)
+                    status)))))))
+
+(defun enkan-repl--terminal-tmux--mirror-mark-closed ()
+  "Mark current tmux mirror buffer as closed."
+  (enkan-repl--terminal-tmux--mirror-stop (current-buffer))
+  (enkan-repl--terminal-tmux--mirror-set-state 'closed)
+  (let ((inhibit-read-only t))
+    (goto-char (point-max))
+    (insert "\n[tmux pane closed]\n")))
+
+(defun enkan-repl--terminal-tmux--mirror-apply-content
+    (buffer id started content status)
+  "Apply async tmux capture CONTENT to BUFFER for ID.
+STARTED is the capture start time.  STATUS is the tmux process exit status."
+  (ignore status)
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (when (equal enkan-repl--tmux-mirror-id id)
+        (setq enkan-repl--tmux-mirror-refresh-process nil)
+        (if (null content)
+            (enkan-repl--terminal-tmux--mirror-mark-closed)
+          (let* ((content-hash (secure-hash 'sha1 content))
+                 (window-state (enkan-repl--terminal-tmux--mirror-window-state
+                                buffer))
+                 (inhibit-read-only t))
+            (setq enkan-repl--tmux-mirror-last-refresh-time (current-time))
+            (setq enkan-repl--tmux-mirror-last-refresh-duration
+                  (float-time
+                   (time-subtract enkan-repl--tmux-mirror-last-refresh-time
+                                  started)))
+            (setq enkan-repl--tmux-mirror-last-refresh-bytes
+                  (string-bytes content))
+            (if (equal content-hash enkan-repl--tmux-mirror-last-content-hash)
+                (enkan-repl--terminal-tmux--mirror-set-state 'unchanged)
+              (setq enkan-repl--tmux-mirror-last-content-hash content-hash)
+              (enkan-repl--terminal-tmux--replace-mirror-content content)
+              (enkan-repl--terminal-tmux--restore-window-state
+               buffer window-state)
+              (enkan-repl--terminal-tmux--mirror-set-state 'fresh))))))))
+
 (defun enkan-repl--terminal-tmux--mirror-refresh (buffer &optional force)
   "Refresh mirror BUFFER by capturing current tmux pane content.
 Skips when BUFFER is dead, hidden, has no bound id, or the tmux pane is gone.
@@ -624,41 +696,29 @@ When FORCE is non-nil, refresh even when BUFFER is hidden."
         (cond
          ((null id))
          ((and (not force)
+               (active-minibuffer-window))
+          (enkan-repl--terminal-tmux--mirror-set-state 'deferred)
+          'deferred)
+         ((and (not force)
                (not (enkan-repl--terminal-tmux--mirror-visible-p buffer)))
           (enkan-repl--terminal-tmux--mirror-set-state 'hidden)
           'hidden)
-         (t
+         ((and enkan-repl--tmux-mirror-refresh-process
+               (process-live-p enkan-repl--tmux-mirror-refresh-process))
           (enkan-repl--terminal-tmux--mirror-set-state 'refreshing)
-          (if (not (enkan-repl--terminal-tmux-alive-p id))
-              (progn
-                ;; Pane is gone -- stop polling and surface a marker.
-                (enkan-repl--terminal-tmux--mirror-stop buffer)
-                (enkan-repl--terminal-tmux--mirror-set-state 'closed)
-                (let ((inhibit-read-only t))
-                  (goto-char (point-max))
-                  (insert "\n[tmux pane closed]\n")))
-            (let* ((started (current-time))
-                   (content (enkan-repl--terminal-tmux--capture-pane
-                             id enkan-repl-tmux-mirror-history-lines))
-                   (content-hash (secure-hash 'sha1 content))
-                   (window-state (enkan-repl--terminal-tmux--mirror-window-state
-                                  buffer))
-                   (inhibit-read-only t))
-              (setq enkan-repl--tmux-mirror-last-refresh-time (current-time))
-              (setq enkan-repl--tmux-mirror-last-refresh-duration
-                    (float-time (time-subtract
-                                 enkan-repl--tmux-mirror-last-refresh-time
-                                 started)))
-              (setq enkan-repl--tmux-mirror-last-refresh-bytes
-                    (string-bytes content))
-              (if (equal content-hash enkan-repl--tmux-mirror-last-content-hash)
-                  (enkan-repl--terminal-tmux--mirror-set-state 'unchanged)
-                (setq enkan-repl--tmux-mirror-last-content-hash content-hash)
-                (enkan-repl--terminal-tmux--replace-mirror-content content)
-                (enkan-repl--terminal-tmux--restore-window-state
-                 buffer window-state)
-                (enkan-repl--terminal-tmux--mirror-set-state 'fresh))
-              enkan-repl--tmux-mirror-state))))))))
+          'refreshing)
+         (t
+          (let ((started (current-time))
+                (target-buffer buffer)
+                (target-id id))
+            (enkan-repl--terminal-tmux--mirror-set-state 'refreshing)
+            (setq enkan-repl--tmux-mirror-refresh-process
+                  (enkan-repl--terminal-tmux--capture-pane-async
+                   id enkan-repl-tmux-mirror-history-lines
+                   (lambda (content status)
+                     (enkan-repl--terminal-tmux--mirror-apply-content
+                      target-buffer target-id started content status))))
+            'refreshing)))))))
 
 (defun enkan-repl--terminal-tmux--mirror-stop (buffer)
   "Cancel mirror refresh timer for BUFFER (if any)."
@@ -668,8 +728,9 @@ When FORCE is non-nil, refresh even when BUFFER is hidden."
         (cancel-timer enkan-repl--tmux-mirror-timer)
         (setq enkan-repl--tmux-mirror-timer nil)))))
 
-(defun enkan-repl--terminal-tmux--mirror-make (id)
-  "Get or create the mirror buffer for tmux ID, set up timer, return it."
+(defun enkan-repl--terminal-tmux--mirror-make (id &optional defer-refresh)
+  "Get or create the mirror buffer for tmux ID, set up timer, return it.
+When DEFER-REFRESH is non-nil, do not immediately refresh the mirror content."
   (let ((buf (get-buffer-create
               (enkan-repl--terminal-tmux--mirror-buffer-name id))))
     (with-current-buffer buf
@@ -684,7 +745,8 @@ When FORCE is non-nil, refresh even when BUFFER is hidden."
                #'enkan-repl--terminal-tmux--mirror-refresh buf)))
       ;; First refresh immediately for instant feedback when visible.  Hidden
       ;; mirrors stay cheap until manually refreshed or displayed.
-      (enkan-repl--terminal-tmux--mirror-refresh buf)
+      (unless defer-refresh
+        (enkan-repl--terminal-tmux--mirror-refresh buf))
       ;; Stop the timer when buffer is killed.
       (add-hook 'kill-buffer-hook
                 (lambda ()
@@ -703,10 +765,37 @@ externally via `enkan-repl-tmux-attach'."
                      " or set `enkan-repl-tmux-mirror' to t."))
     nil)
    (t
-    (let ((buf (enkan-repl--terminal-tmux--mirror-make id)))
+    (let ((buf (enkan-repl--terminal-tmux--mirror-make id t)))
       (pop-to-buffer-same-window buf)
       (enkan-repl--terminal-tmux--mirror-refresh buf t)
       buf))))
+
+;;;###autoload
+(defun enkan-repl-tmux-refresh-workspace (&optional quiet)
+  "Refresh tmux mirror buffers for the current workspace.
+Mirror buffers are created for live tmux windows that do not yet have one.
+When QUIET is non-nil, suppress the status message.
+Returns the number of refreshed mirror buffers."
+  (interactive)
+  (unless (eq enkan-repl-terminal-backend 'tmux)
+    (user-error "Current terminal backend is not tmux: %S"
+                enkan-repl-terminal-backend))
+  (unless enkan-repl-tmux-mirror
+    (user-error "Tmux mirror is disabled"))
+  (let ((ids (enkan-repl--terminal-tmux-list))
+        (count 0))
+    (dolist (id ids)
+      (let ((buf (enkan-repl--terminal-tmux--mirror-make id t)))
+        (when buf
+          (enkan-repl--terminal-tmux--mirror-refresh buf t)
+          (setq count (1+ count)))))
+    (unless quiet
+      (message "Refreshed %d tmux mirror buffer(s) for workspace %s"
+               count
+               (or (and (boundp 'enkan-repl--current-workspace)
+                        enkan-repl--current-workspace)
+                   "<none>")))
+    count))
 
 ;;;###autoload
 (defun enkan-repl-tmux-refresh-current ()

--- a/enkan-repl-terminal.el
+++ b/enkan-repl-terminal.el
@@ -35,6 +35,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 
 (defgroup enkan-repl-terminal nil
   "Terminal backend selection for enkan-repl."
@@ -69,6 +70,8 @@ migrated when the value changes."
                   "enkan-repl-utils" (name workspace-id))
 (declare-function enkan-repl-state--list-live-tmux-sessions
                   "enkan-repl-state" (prefix))
+(declare-function enkan-repl-notify-task-complete
+                  "enkan-repl-mac-notify" (&optional message))
 (defvar eat--process)
 (defvar enkan-repl--current-workspace)
 
@@ -139,11 +142,14 @@ Return non-nil on success."
 
 (defun enkan-repl--terminal-alive-p (id)
   "Return non-nil if terminal ID is alive."
-  (enkan-repl--terminal--dispatch
-   'alive-p
-   #'enkan-repl--terminal-eat-alive-p
-   #'enkan-repl--terminal-tmux-alive-p
-   id))
+  (if (and (eq enkan-repl-terminal-backend 'tmux)
+           (bufferp id))
+      (enkan-repl--terminal-tmux-mirror-buffer-alive-p id)
+    (enkan-repl--terminal--dispatch
+     'alive-p
+     #'enkan-repl--terminal-eat-alive-p
+     #'enkan-repl--terminal-tmux-alive-p
+     id)))
 
 (defun enkan-repl--terminal-list ()
   "Return list of identifiers for sessions in current workspace."
@@ -275,6 +281,14 @@ like \"enkan-01\"."
   :type 'string
   :group 'enkan-repl-terminal)
 
+(defcustom enkan-repl-tmux-command-timeout 2.0
+  "Maximum seconds to wait for synchronous tmux control commands.
+This applies to lightweight control operations such as session/window
+enumeration, send-keys, and kill commands.  Pane capture uses the separate
+`enkan-repl-tmux-mirror-capture-timeout'."
+  :type 'number
+  :group 'enkan-repl-terminal)
+
 (defun enkan-repl--terminal-tmux--workspace-session ()
   "Return the tmux session name corresponding to current workspace, or nil."
   (when (and (boundp 'enkan-repl--current-workspace)
@@ -287,17 +301,53 @@ When CAPTURE is non-nil, return stdout as a string (trailing newline stripped),
 or nil on non-zero exit.  Otherwise return t on zero exit, nil on non-zero."
   (unless (executable-find enkan-repl-tmux-executable)
     (user-error "Tmux executable not found: %s" enkan-repl-tmux-executable))
-  (with-temp-buffer
-    (let ((status (apply #'call-process
-                         enkan-repl-tmux-executable
-                         nil (current-buffer) nil args)))
-      (cond
-       ((not (zerop status)) nil)
-       (capture (let ((s (buffer-substring-no-properties (point-min) (point-max))))
-                  (if (string-suffix-p "\n" s)
-                      (substring s 0 -1)
-                    s)))
-       (t t)))))
+  (let* ((timeout (and (numberp enkan-repl-tmux-command-timeout)
+                       (> enkan-repl-tmux-command-timeout 0)
+                       enkan-repl-tmux-command-timeout))
+         (deadline (and timeout
+                        (+ (float-time) timeout)))
+         (output-buffer (and capture
+                             (generate-new-buffer " *enkan-repl tmux call*")))
+         (done nil)
+         (status nil)
+         process)
+    (unwind-protect
+        (progn
+          (setq process
+                (make-process
+                 :name "enkan-tmux-call"
+                 :buffer output-buffer
+                 :command (cons enkan-repl-tmux-executable args)
+                 :connection-type 'pipe
+                 :noquery t
+                 :sentinel (lambda (proc _event)
+                             (when (memq (process-status proc) '(exit signal))
+                               (setq status (process-exit-status proc))
+                               (setq done t)))))
+          (while (and (not done)
+                      (process-live-p process)
+                      (or (not deadline) (< (float-time) deadline)))
+            (accept-process-output process 0.05)
+            (when (and (not done)
+                       (memq (process-status process) '(exit signal)))
+              (setq status (process-exit-status process))
+              (setq done t)))
+          (unless done
+            (when (process-live-p process)
+              (delete-process process))
+            (setq status 'timeout))
+          (cond
+           ((not (and (integerp status) (zerop status))) nil)
+           (capture
+            (with-current-buffer output-buffer
+              (let ((s (buffer-substring-no-properties
+                        (point-min) (point-max))))
+                (if (string-suffix-p "\n" s)
+                    (substring s 0 -1)
+                  s))))
+           (t t)))
+      (when (buffer-live-p output-buffer)
+        (kill-buffer output-buffer)))))
 
 (defun enkan-repl--terminal-tmux--has-session (session)
   "Return non-nil if tmux SESSION exists."
@@ -352,6 +402,7 @@ target identifier (e.g. \"enkan-01:lat\")."
                       (user-error "No current workspace; cannot start tmux session")))
          (base (enkan-repl--terminal-tmux--derive-base-name dir))
          (cdir (expand-file-name dir)))
+    (enkan-repl--terminal-tmux--ensure-bell-monitor)
     (cond
      ;; Session does not exist: create it with the first window in DIR.
      ((not (enkan-repl--terminal-tmux--has-session session))
@@ -417,15 +468,127 @@ mirror buffer."
   :type 'boolean
   :group 'enkan-repl-terminal)
 
+(defcustom enkan-repl-tmux-mirror-auto-refresh nil
+  "When non-nil, tmux mirror buffers refresh themselves on an idle timer.
+The default is nil because mirror refresh can still involve main-thread buffer
+updates.  Use `enkan-repl-tmux-refresh-current' or
+`enkan-repl-tmux-refresh-workspace' for explicit refreshes."
+  :type 'boolean
+  :group 'enkan-repl-terminal)
+
 (defcustom enkan-repl-tmux-mirror-interval 5.0
-  "Idle interval (seconds) between `tmux capture-pane' refreshes.
-Applies to every active tmux mirror buffer."
+  "Idle interval (seconds) used when tmux mirror auto-refresh is enabled.
+This is ignored unless `enkan-repl-tmux-mirror-auto-refresh' is non-nil."
   :type 'number
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-history-lines 500
-  "Number of scrollback lines to capture per refresh tick."
+(defcustom enkan-repl-tmux-bell-notify t
+  "When non-nil, watch tmux alerts and notify task completion or prompts.
+This is independent from mirror auto-refresh.  Permission prompt detection uses
+a small bounded capture and refreshes only the target that triggered a
+notification."
+  :type 'boolean
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-bell-notify-interval 2.0
+  "Seconds between lightweight tmux bell alert checks."
+  :type 'number
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-bell-notify-timeout 0.2
+  "Maximum seconds to wait for one tmux bell alert check."
+  :type 'number
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-prompt-notify t
+  "When non-nil, notify for Claude Code/Codex CLI permission prompts."
+  :type 'boolean
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-prompt-notify-lines 40
+  "Recent tmux lines inspected for permission prompts."
   :type 'integer
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-prompt-notify-max-chars (* 16 1024)
+  "Maximum characters inspected per tmux pane for prompt notifications."
+  :type 'integer
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-prompt-notify-patterns
+  '("permission[[:space:]-]+\\(required\\|requested\\|needed\\)"
+    "\\(requires\\|needs\\)[[:space:]]+\\(approval\\|permission\\)"
+    "\\(approval\\|permission\\)[[:space:]-]+\\(required\\|requested\\|needed\\)"
+    "waiting[[:space:]]+for[[:space:]]+\\(approval\\|permission\\)"
+    "\\(allow\\|approve\\|deny\\|reject\\)[[:space:]]+\\(command\\|execution\\|tool\\)"
+    "\\(allow\\|approve\\)[^?\n]*\\?"
+    "do you want to \\(continue\\|proceed\\|run\\|execute\\|allow\\)"
+    "\\b\\(y/n\\|yes/no\\)\\b")
+  "Case-insensitive regexps that identify CLI permission prompts."
+  :type '(repeat regexp)
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-activity-notify t
+  "When non-nil, notify after tmux pane output changes and then settles.
+This covers CLIs that do not emit a terminal bell when an answer finishes.
+The monitor uses the same small bounded capture as prompt notifications; it
+does not re-enable periodic full mirror refresh."
+  :type 'boolean
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-activity-notify-idle-seconds 1.5
+  "Seconds of unchanged alert-capture content before notifying completion."
+  :type 'number
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-alert-capture-targets-per-poll 4
+  "Maximum number of tmux targets inspected with capture-pane per poll.
+Bell flags remain checked for all sessions every poll.  Prompt and activity
+notifications use bounded pane captures, so this limit caps worst-case UI
+latency when many background panes exist."
+  :type 'integer
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-mirror-history-lines 160
+  "Number of recent tmux lines to capture per refresh.
+The mirror is a lightweight status view, not a full transcript.  Keep this
+small enough that manual refresh remains cheap after a long idle period."
+  :type 'integer
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-mirror-display-lines 80
+  "Maximum number of lines kept in a tmux mirror buffer."
+  :type 'integer
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-mirror-max-chars (* 64 1024)
+  "Maximum characters to apply to a tmux mirror buffer per refresh.
+When captured content is larger than this value, keep the tail of the
+capture.  This bounds main-thread work after the asynchronous tmux
+process returns."
+  :type 'integer
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-mirror-compact-noisy-blocks t
+  "When non-nil, collapse large diff-like or very long output blocks."
+  :type 'boolean
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-mirror-noisy-block-threshold 6
+  "Minimum consecutive noisy lines collapsed into one mirror summary line."
+  :type 'integer
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-mirror-max-line-length 240
+  "Maximum line length shown verbatim in tmux mirror buffers."
+  :type 'integer
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-mirror-capture-timeout 3.0
+  "Seconds before an in-flight tmux mirror capture is cancelled.
+This bounds how long `enkan-repl-tmux-refresh-current' can wait on a stuck
+tmux capture process."
+  :type 'number
   :group 'enkan-repl-terminal)
 
 (defvar-local enkan-repl--tmux-mirror-id nil
@@ -436,6 +599,9 @@ Applies to every active tmux mirror buffer."
 
 (defvar-local enkan-repl--tmux-mirror-refresh-process nil
   "Buffer-local asynchronous `tmux capture-pane' process.")
+
+(defvar-local enkan-repl--tmux-mirror-cwd-process nil
+  "Buffer-local asynchronous tmux pane cwd lookup process.")
 
 (defvar-local enkan-repl--tmux-mirror-state 'idle
   "Buffer-local refresh state for the tmux mirror buffer.")
@@ -451,6 +617,19 @@ Applies to every active tmux mirror buffer."
 
 (defvar-local enkan-repl--tmux-mirror-last-content-hash nil
   "Buffer-local hash of the last captured tmux mirror content.")
+
+(defvar enkan-repl--tmux-bell-monitor-timer nil
+  "Timer used to poll tmux bell alerts for completion notifications.")
+
+(defvar enkan-repl--tmux-bell-monitor-seen (make-hash-table :test #'equal)
+  "Tmux alert keys already notified while their condition remains set.")
+
+(defvar enkan-repl--tmux-bell-monitor-content-state
+  (make-hash-table :test #'equal)
+  "Per-target small-capture state used for tmux activity notifications.")
+
+(defvar enkan-repl--tmux-bell-monitor-target-cursor 0
+  "Round-robin cursor for bounded tmux alert capture polling.")
 
 (defvar enkan-repl-tmux-mirror-mode-map
   (let ((map (make-sparse-keymap)))
@@ -500,11 +679,277 @@ Applies to every active tmux mirror buffer."
 (defun enkan-repl--terminal-tmux--mirror-set-state (state)
   "Set tmux mirror refresh STATE and refresh visible status immediately."
   (setq enkan-repl--tmux-mirror-state state)
-  (enkan-repl--terminal-tmux--mirror-update-status)
-  ;; A visible "refreshing" marker only helps if redisplay happens before the
-  ;; synchronous tmux process call starts.
-  (when (eq state 'refreshing)
-    (redisplay t)))
+  (enkan-repl--terminal-tmux--mirror-update-status))
+
+(defun enkan-repl--terminal-tmux--mirror-auto-refresh-enabled-p ()
+  "Return non-nil when tmux mirror auto-refresh should run."
+  (and enkan-repl-tmux-mirror-auto-refresh
+       (numberp enkan-repl-tmux-mirror-interval)
+       (> enkan-repl-tmux-mirror-interval 0)))
+
+(defun enkan-repl--terminal-tmux--bell-monitor-enabled-p ()
+  "Return non-nil when tmux bell notification monitoring should run."
+  (and enkan-repl-tmux-bell-notify
+       (numberp enkan-repl-tmux-bell-notify-interval)
+       (> enkan-repl-tmux-bell-notify-interval 0)))
+
+(defun enkan-repl--terminal-tmux--bell-monitor-sessions ()
+  "Return tmux sessions that should be checked for bell alerts."
+  (let ((enkan-repl-tmux-command-timeout
+         (if (and (numberp enkan-repl-tmux-bell-notify-timeout)
+                  (> enkan-repl-tmux-bell-notify-timeout 0))
+             enkan-repl-tmux-bell-notify-timeout
+           0.2)))
+    (cl-remove-duplicates
+     (delq nil
+           (if (fboundp 'enkan-repl-state--list-live-tmux-sessions)
+               (enkan-repl-state--list-live-tmux-sessions
+                enkan-repl-tmux-session-prefix)
+             (list (enkan-repl--terminal-tmux--workspace-session))))
+     :test #'equal)))
+
+(defun enkan-repl--terminal-tmux--bell-alert-targets (session)
+  "Return tmux target ids with a bell alert flag in SESSION."
+  (let* ((enkan-repl-tmux-command-timeout
+          (if (and (numberp enkan-repl-tmux-bell-notify-timeout)
+                   (> enkan-repl-tmux-bell-notify-timeout 0))
+              enkan-repl-tmux-bell-notify-timeout
+            0.2))
+         (out (enkan-repl--terminal-tmux--call
+               (list "list-windows" "-t" session "-F"
+                     "#{window_name}\t#{window_bell_flag}")
+               t)))
+    (when (stringp out)
+      (delq
+       nil
+       (mapcar
+        (lambda (line)
+          (pcase-let ((`(,window ,flag) (split-string line "\t")))
+            (when (and window (string= flag "1"))
+              (enkan-repl--terminal-tmux--make-id session window))))
+        (split-string out "\n" t))))))
+
+(defun enkan-repl--terminal-tmux--all-targets (session)
+  "Return all tmux target ids in SESSION."
+  (let ((windows (enkan-repl--terminal-tmux--list-windows session)))
+    (mapcar (lambda (window)
+              (enkan-repl--terminal-tmux--make-id session window))
+            windows)))
+
+(defun enkan-repl--terminal-tmux--alert-capture (target)
+  "Return a small bounded capture from TARGET for alert detection."
+  (let* ((lines (if (and (integerp enkan-repl-tmux-prompt-notify-lines)
+                         (> enkan-repl-tmux-prompt-notify-lines 0))
+                    enkan-repl-tmux-prompt-notify-lines
+                  40))
+         (max-chars (and (integerp enkan-repl-tmux-prompt-notify-max-chars)
+                         (> enkan-repl-tmux-prompt-notify-max-chars 0)
+                         enkan-repl-tmux-prompt-notify-max-chars))
+         (enkan-repl-tmux-command-timeout
+          (if (and (numberp enkan-repl-tmux-bell-notify-timeout)
+                   (> enkan-repl-tmux-bell-notify-timeout 0))
+              enkan-repl-tmux-bell-notify-timeout
+            0.2))
+         (out (enkan-repl--terminal-tmux--call
+               (list "capture-pane" "-p" "-J" "-S"
+                     (format "-%d" lines)
+                     "-t" target)
+               t)))
+    (when (stringp out)
+      (if (and max-chars (> (length out) max-chars))
+          (substring out (- max-chars))
+        out))))
+
+(defun enkan-repl--terminal-tmux--prompt-content-p (content)
+  "Return non-nil when CONTENT looks like a CLI permission prompt."
+  (let ((case-fold-search t)
+        (patterns enkan-repl-tmux-prompt-notify-patterns)
+        matched)
+    (while (and patterns (not matched))
+      (setq matched (string-match-p (car patterns) content))
+      (setq patterns (cdr patterns)))
+    matched))
+
+(defun enkan-repl--terminal-tmux--prompt-alert-targets (session)
+  "Return tmux target ids in SESSION that look like permission prompts."
+  (when enkan-repl-tmux-prompt-notify
+    (delq
+     nil
+     (mapcar
+      (lambda (target)
+        (let ((content (enkan-repl--terminal-tmux--alert-capture target)))
+          (when (and content
+                     (enkan-repl--terminal-tmux--prompt-content-p content))
+            target)))
+      (enkan-repl--terminal-tmux--all-targets session)))))
+
+(defun enkan-repl--terminal-tmux--activity-notify-enabled-p ()
+  "Return non-nil when tmux content-settled notifications should run."
+  (and enkan-repl-tmux-activity-notify
+       (numberp enkan-repl-tmux-activity-notify-idle-seconds)
+       (>= enkan-repl-tmux-activity-notify-idle-seconds 0)))
+
+(defun enkan-repl--terminal-tmux--activity-alert-p (target content now)
+  "Return non-nil when TARGET CONTENT has changed and then settled by NOW.
+The first observation only establishes a baseline.  Later content changes mark
+the target active, and a notification is emitted once the small capture remains
+unchanged for `enkan-repl-tmux-activity-notify-idle-seconds'."
+  (when (and (enkan-repl--terminal-tmux--activity-notify-enabled-p)
+             (stringp content))
+    (let* ((hash (secure-hash 'sha1 content))
+           (state (gethash target
+                           enkan-repl--tmux-bell-monitor-content-state))
+           (previous-hash (plist-get state :hash))
+           (changed-at (or (plist-get state :changed-at) now))
+           (notified (plist-get state :notified)))
+      (cond
+       ((null state)
+        (puthash target
+                 (list :hash hash :changed-at now :notified t)
+                 enkan-repl--tmux-bell-monitor-content-state)
+        nil)
+       ((not (equal hash previous-hash))
+        (puthash target
+                 (list :hash hash :changed-at now :notified nil)
+                 enkan-repl--tmux-bell-monitor-content-state)
+        nil)
+       ((not notified)
+        (let ((settled-p
+               (>= (float-time (time-subtract now changed-at))
+                   enkan-repl-tmux-activity-notify-idle-seconds)))
+          (when settled-p
+            (puthash target
+                     (list :hash hash :changed-at changed-at :notified t)
+                     enkan-repl--tmux-bell-monitor-content-state))
+          settled-p))
+       (t nil)))))
+
+(defun enkan-repl--terminal-tmux--alert-target-slice (targets)
+  "Return the bounded round-robin subset of TARGETS to capture this poll."
+  (let* ((targets (cl-remove-duplicates targets :test #'equal))
+         (len (length targets))
+         (limit (if (and (integerp enkan-repl-tmux-alert-capture-targets-per-poll)
+                         (> enkan-repl-tmux-alert-capture-targets-per-poll 0))
+                    enkan-repl-tmux-alert-capture-targets-per-poll
+                  len)))
+    (cond
+     ((zerop len) nil)
+     ((>= limit len)
+      (setq enkan-repl--tmux-bell-monitor-target-cursor 0)
+      targets)
+     (t
+      (let ((start (mod enkan-repl--tmux-bell-monitor-target-cursor len))
+            selected)
+        (dotimes (i limit)
+          (push (nth (mod (+ start i) len) targets) selected))
+        (setq enkan-repl--tmux-bell-monitor-target-cursor
+              (mod (+ start limit) len))
+        (nreverse selected))))))
+
+(defun enkan-repl--terminal-tmux--alert-key (kind target)
+  "Return a stable de-duplication key for alert KIND and TARGET."
+  (format "%s\t%s" kind target))
+
+(defun enkan-repl--terminal-tmux--refresh-alert-target (target)
+  "Force-refresh the mirror buffer for alert TARGET."
+  (when enkan-repl-tmux-mirror
+    (let ((buf (enkan-repl--terminal-tmux--mirror-make target t)))
+      (when buf
+        (enkan-repl--terminal-tmux--mirror-refresh buf t)))))
+
+(defun enkan-repl--terminal-tmux--bell-notify (target &optional kind)
+  "Refresh and notify that tmux TARGET emitted alert KIND."
+  (enkan-repl--terminal-tmux--refresh-alert-target target)
+  (if (fboundp 'enkan-repl-notify-task-complete)
+      (enkan-repl-notify-task-complete
+       (pcase kind
+         ('prompt (format "tmux permission requested: %s" target))
+         ('activity (format "tmux task completed: %s" target))
+         (_ (format "tmux task completed: %s" target))))
+    (message "%s"
+             (pcase kind
+               ('prompt (format "tmux permission requested: %s" target))
+               ('activity (format "tmux task completed: %s" target))
+               (_ (format "tmux task completed: %s" target))))))
+
+(defun enkan-repl--terminal-tmux--bell-monitor-poll ()
+  "Poll tmux alert flags/prompts and notify newly observed alerts."
+  (when (enkan-repl--terminal-tmux--bell-monitor-enabled-p)
+    (let ((active (make-hash-table :test #'equal))
+          (seen-targets (make-hash-table :test #'equal))
+          targets-to-capture
+          (now (current-time)))
+      (dolist (session (enkan-repl--terminal-tmux--bell-monitor-sessions))
+        (dolist (target (enkan-repl--terminal-tmux--bell-alert-targets session))
+          (let ((key (enkan-repl--terminal-tmux--alert-key 'bell target)))
+            (puthash key t active)
+            (unless (gethash key enkan-repl--tmux-bell-monitor-seen)
+              (puthash key t enkan-repl--tmux-bell-monitor-seen)
+              (enkan-repl--terminal-tmux--bell-notify target 'bell))))
+        (dolist (target (enkan-repl--terminal-tmux--all-targets session))
+          (puthash target t seen-targets)
+          (push target targets-to-capture)))
+      (dolist (target (enkan-repl--terminal-tmux--alert-target-slice
+                       (nreverse targets-to-capture)))
+        (when (gethash target seen-targets)
+          (let* ((content (enkan-repl--terminal-tmux--alert-capture target))
+                 (prompt-p (and content
+                                enkan-repl-tmux-prompt-notify
+                                (enkan-repl--terminal-tmux--prompt-content-p
+                                 content)))
+                 (activity-p
+                  (enkan-repl--terminal-tmux--activity-alert-p
+                   target content now)))
+            (when prompt-p
+              (let ((key (enkan-repl--terminal-tmux--alert-key 'prompt target)))
+                (puthash key t active)
+                (unless (gethash key enkan-repl--tmux-bell-monitor-seen)
+                  (puthash key t enkan-repl--tmux-bell-monitor-seen)
+                  (enkan-repl--terminal-tmux--bell-notify target 'prompt))))
+            (when activity-p
+              (enkan-repl--terminal-tmux--bell-notify target 'activity)))))
+      (maphash
+       (lambda (key _)
+         (unless (gethash key active)
+           (remhash key enkan-repl--tmux-bell-monitor-seen)))
+       enkan-repl--tmux-bell-monitor-seen)
+      (maphash
+       (lambda (target _)
+         (unless (gethash target seen-targets)
+           (remhash target enkan-repl--tmux-bell-monitor-content-state)))
+       enkan-repl--tmux-bell-monitor-content-state))))
+
+(defun enkan-repl--terminal-tmux--ensure-bell-monitor ()
+  "Start tmux bell notification monitoring when enabled."
+  (when (and (enkan-repl--terminal-tmux--bell-monitor-enabled-p)
+             (not enkan-repl--tmux-bell-monitor-timer))
+    (setq enkan-repl--tmux-bell-monitor-timer
+          (run-with-timer
+           enkan-repl-tmux-bell-notify-interval
+           enkan-repl-tmux-bell-notify-interval
+           #'enkan-repl--terminal-tmux--bell-monitor-poll))))
+
+(defun enkan-repl-tmux-stop-bell-monitor ()
+  "Stop tmux bell notification monitoring."
+  (interactive)
+  (when enkan-repl--tmux-bell-monitor-timer
+    (cancel-timer enkan-repl--tmux-bell-monitor-timer)
+    (setq enkan-repl--tmux-bell-monitor-timer nil))
+  (clrhash enkan-repl--tmux-bell-monitor-seen)
+  (clrhash enkan-repl--tmux-bell-monitor-content-state)
+  (setq enkan-repl--tmux-bell-monitor-target-cursor 0))
+
+(defun enkan-repl--terminal-tmux-mirror-buffer-alive-p (buffer)
+  "Return non-nil when BUFFER is an open tmux mirror.
+This is intentionally an Emacs-local check.  UI paths call this while scanning
+`buffer-list', so it must not synchronously query tmux."
+  (and (bufferp buffer)
+       (buffer-live-p buffer)
+       (buffer-local-boundp 'enkan-repl--tmux-mirror-id buffer)
+       (buffer-local-value 'enkan-repl--tmux-mirror-id buffer)
+       (not (and (buffer-local-boundp 'enkan-repl--tmux-mirror-state buffer)
+                 (eq (buffer-local-value 'enkan-repl--tmux-mirror-state buffer)
+                     'closed)))))
 
 (defun enkan-repl--terminal-tmux-kill-workspace (workspace-id)
   "Kill the tmux session backing WORKSPACE-ID.
@@ -514,27 +959,10 @@ Returns non-nil when a live tmux session was killed."
     (when (and session (enkan-repl--terminal-tmux--has-session session))
       (enkan-repl--terminal-tmux--call (list "kill-session" "-t" session)))))
 
-(defun enkan-repl--terminal-tmux--line-column-at (position)
-  "Return a cons cell of line and column at POSITION in the current buffer."
-  (save-excursion
-    (goto-char position)
-    (cons (line-number-at-pos nil t) (current-column))))
-
-(defun enkan-repl--terminal-tmux--position-at-line-column (line-column)
-  "Return buffer position for LINE-COLUMN in the current buffer."
-  (save-excursion
-    (goto-char (point-min))
-    (forward-line (1- (car line-column)))
-    (move-to-column (cdr line-column))
-    (point)))
-
 (defun enkan-repl--terminal-tmux--window-at-bottom-p (window)
   "Return non-nil when WINDOW is displaying the current buffer bottom."
   (or (= (window-point window) (point-max))
-      (let ((start-line (line-number-at-pos (window-start window) t))
-            (end-line (line-number-at-pos (point-max) t))
-            (height (max 1 (window-body-height window))))
-        (<= end-line (+ start-line height)))))
+      (pos-visible-in-window-p (point-max) window t)))
 
 (defun enkan-repl--terminal-tmux--mirror-window-state (buffer)
   "Capture scroll state for windows currently displaying BUFFER."
@@ -543,10 +971,8 @@ Returns non-nil when a live tmux session was killed."
      (lambda (window)
        (list :window window
              :at-bottom (enkan-repl--terminal-tmux--window-at-bottom-p window)
-             :start (enkan-repl--terminal-tmux--line-column-at
-                     (window-start window))
-             :point (enkan-repl--terminal-tmux--line-column-at
-                     (window-point window))))
+             :start (window-start window)
+             :point (window-point window)))
      (get-buffer-window-list buffer nil t))))
 
 (defun enkan-repl--terminal-tmux--restore-window-state (buffer states)
@@ -560,61 +986,271 @@ bottom.  Other windows keep their previous line and column."
           (when (and (window-live-p window)
                      (eq (window-buffer window) buffer))
             (if (plist-get state :at-bottom)
-                (let* ((height (max 1 (window-body-height window)))
-                       (end-line (line-number-at-pos (point-max) t))
-                       (start-line (max 1 (- end-line height -1)))
-                       (start (enkan-repl--terminal-tmux--position-at-line-column
-                               (cons start-line 0))))
-                  (set-window-point window (point-max))
-                  (set-window-start window start))
-              (let ((start (enkan-repl--terminal-tmux--position-at-line-column
-                            (plist-get state :start)))
-                    (point (enkan-repl--terminal-tmux--position-at-line-column
-                            (plist-get state :point))))
+                (progn
+                  (set-window-point window (point-max)))
+              (let ((start (min (point-max) (plist-get state :start)))
+                    (point (min (point-max) (plist-get state :point))))
                 (set-window-point window point)
                 (set-window-start window start)))))))))
 
 (defun enkan-repl--terminal-tmux--replace-mirror-content (content)
-  "Replace the current tmux mirror buffer with CONTENT while preserving markers."
-  (let ((source (generate-new-buffer " *enkan-repl tmux capture*")))
-    (unwind-protect
-        (progn
-          (with-current-buffer source
-            (insert content))
-          (replace-buffer-contents source))
-      (kill-buffer source))))
+  "Replace the current tmux mirror buffer with CONTENT.
+This intentionally avoids `replace-buffer-contents'.  Mirror buffers are a
+bounded recent-status view, and diffing a stale huge buffer is unnecessary
+main-thread work."
+  (erase-buffer)
+  (insert content))
 
-(defun enkan-repl--terminal-tmux--pane-cwd (id)
-  "Return current working directory of tmux pane ID, or nil."
-  (enkan-repl--terminal-tmux--call
-   (list "display-message" "-p" "-t" id "#{pane_current_path}")
-   t))
+(defun enkan-repl--terminal-tmux--mirror-fallback-buffer-name (id)
+  "Return a non-blocking fallback mirror buffer name for tmux ID."
+  (format "*tmux %s*" id))
 
-(defun enkan-repl--terminal-tmux--mirror-buffer-name (id)
-  "Return mirror buffer name for tmux ID.
-Uses the same `*ws:NN enkan:/path/*' form as the eat backend so that
-existing buffer-list-based layout / lookup code finds tmux mirror
-buffers transparently.  The path is normalized via
-`file-name-as-directory' so the trailing slash matches what
-`enkan-repl--path->buffer-name' produces from `enkan-repl-target-directories'
-entries (which include the trailing slash).  Falls back to
-`*tmux <id>*' when the path cannot be determined."
-  (let ((path (enkan-repl--terminal-tmux--pane-cwd id))
-        (instance (enkan-repl--terminal-tmux-id-instance id)))
-    (cond
-     ((and path (not (string-empty-p path)))
-      (enkan-repl--path->buffer-name (file-name-as-directory path) instance))
-     (t (format "*tmux %s*" id)))))
+(defun enkan-repl--terminal-tmux--id-workspace (id)
+  "Return workspace id encoded in tmux target ID, or nil.
+For example, with `enkan-repl-tmux-session-prefix' set to \"enkan-\",
+\"enkan-02:lat\" maps to \"02\"."
+  (let ((session (enkan-repl--terminal-tmux--id-session id))
+        (prefix enkan-repl-tmux-session-prefix))
+    (when (and (stringp session)
+               (stringp prefix)
+               (string-prefix-p prefix session)
+               (> (length session) (length prefix)))
+      (substring session (length prefix)))))
 
-(defun enkan-repl--terminal-tmux--capture-pane (id lines)
-  "Return current pane content of tmux ID as a string (best effort).
-LINES is the maximum scrollback to include (negative numbers per
-`tmux capture-pane -S' semantics)."
-  (or (enkan-repl--terminal-tmux--call
-       (list "capture-pane" "-p" "-J" "-S" (format "-%d" (max 0 lines))
-             "-t" id)
-       t)
-      ""))
+(defun enkan-repl--terminal-tmux--mirror-buffer-name-for-path (id path)
+  "Return path-based mirror buffer name for tmux ID at PATH.
+The name uses the same `*ws:NN enkan:/path/*' form as the eat backend so
+buffer-list-based layout and send-target lookup can find tmux mirrors."
+  (let ((enkan-repl--current-workspace
+         (or (enkan-repl--terminal-tmux--id-workspace id)
+             enkan-repl--current-workspace)))
+    (enkan-repl--path->buffer-name
+     (file-name-as-directory path)
+     (enkan-repl--terminal-tmux-id-instance id))))
+
+(defun enkan-repl--terminal-tmux--mirror-buffer-name (id &optional path)
+  "Return mirror buffer name for tmux ID without calling tmux.
+When PATH is non-nil, return the path-based eat-compatible name.
+Otherwise return a tmux-id fallback name.  Pane cwd discovery is done
+asynchronously by `enkan-repl--terminal-tmux--mirror-make'."
+  (if (and path (not (string-empty-p path)))
+      (enkan-repl--terminal-tmux--mirror-buffer-name-for-path id path)
+    (enkan-repl--terminal-tmux--mirror-fallback-buffer-name id)))
+
+(defun enkan-repl--terminal-tmux--find-mirror-buffer (id)
+  "Return an existing tmux mirror buffer for ID, or nil."
+  (cl-find-if
+   (lambda (buffer)
+     (and (buffer-live-p buffer)
+          (buffer-local-boundp 'enkan-repl--tmux-mirror-id buffer)
+          (equal (buffer-local-value 'enkan-repl--tmux-mirror-id buffer)
+                 id)))
+   (buffer-list)))
+
+(defun enkan-repl--terminal-tmux--repair-mirror-buffer-name (buffer)
+  "Repair BUFFER's workspace prefix from its tmux mirror id.
+Return non-nil when BUFFER was renamed.  This uses only Emacs-local metadata
+and the existing buffer path; it does not call tmux."
+  (when (and (buffer-live-p buffer)
+             (buffer-local-boundp 'enkan-repl--tmux-mirror-id buffer))
+    (let* ((id (buffer-local-value 'enkan-repl--tmux-mirror-id buffer))
+           (workspace (and id
+                           (enkan-repl--terminal-tmux--id-workspace id)))
+           (path (enkan-repl--buffer-name->path (buffer-name buffer))))
+      (when (and workspace path)
+        (let* ((enkan-repl--current-workspace workspace)
+               (expected-name
+                (enkan-repl--path->buffer-name
+                 path
+                 (enkan-repl--terminal-tmux-id-instance id))))
+          (unless (string= (buffer-name buffer) expected-name)
+            (with-current-buffer buffer
+              (rename-buffer expected-name t))
+            t))))))
+
+;;;###autoload
+(defun enkan-repl-tmux-repair-mirror-buffer-names ()
+  "Repair tmux mirror buffer workspace prefixes from their tmux target ids.
+This fixes already-created mirror buffers whose `*ws:NN enkan:...*' name was
+derived from the current Emacs workspace instead of the tmux target session."
+  (interactive)
+  (let ((count 0))
+    (dolist (buffer (buffer-list))
+      (when (enkan-repl--terminal-tmux--repair-mirror-buffer-name buffer)
+        (setq count (1+ count))))
+    (message "Repaired %d tmux mirror buffer name(s)" count)
+    count))
+
+(defun enkan-repl--terminal-tmux--pane-cwd-async (id callback)
+  "Resolve tmux pane cwd for ID asynchronously, then call CALLBACK.
+CALLBACK receives the cwd string, or nil on failure."
+  (unless (executable-find enkan-repl-tmux-executable)
+    (user-error "Tmux executable not found: %s" enkan-repl-tmux-executable))
+  (let* ((output-buffer (generate-new-buffer " *enkan-repl tmux cwd*"))
+         (command (list enkan-repl-tmux-executable
+                        "display-message" "-p" "-t" id
+                        "#{pane_current_path}")))
+    (make-process
+     :name (format "enkan-tmux-cwd %s" id)
+     :buffer output-buffer
+     :command command
+     :connection-type 'pipe
+     :noquery t
+     :sentinel
+     (lambda (process _event)
+       (when (memq (process-status process) '(exit signal))
+         (let* ((status (process-exit-status process))
+                (content (when (buffer-live-p output-buffer)
+                           (with-current-buffer output-buffer
+                             (string-trim
+                              (buffer-substring-no-properties
+                               (point-min) (point-max)))))))
+           (when (buffer-live-p output-buffer)
+             (kill-buffer output-buffer))
+           (funcall callback
+                    (and (zerop status)
+                         content
+                         (not (string-empty-p content))
+                         content))))))))
+
+(defun enkan-repl--terminal-tmux--mirror-rename-for-cwd (buffer id cwd)
+  "Rename mirror BUFFER for ID using CWD when it is still current."
+  (when (and cwd (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (when (equal enkan-repl--tmux-mirror-id id)
+        (let ((name (enkan-repl--terminal-tmux--mirror-buffer-name id cwd)))
+          (unless (string= (buffer-name buffer) name)
+            (rename-buffer name t)))))))
+
+(defun enkan-repl--terminal-tmux--mirror-start-cwd-lookup (buffer id)
+  "Start asynchronous cwd lookup for mirror BUFFER bound to ID."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (unless (and enkan-repl--tmux-mirror-cwd-process
+                   (process-live-p enkan-repl--tmux-mirror-cwd-process))
+        (let ((target-buffer buffer)
+              (target-id id))
+          (setq enkan-repl--tmux-mirror-cwd-process
+                (enkan-repl--terminal-tmux--pane-cwd-async
+                 id
+                 (lambda (cwd)
+                   (when (buffer-live-p target-buffer)
+                     (with-current-buffer target-buffer
+                       (setq enkan-repl--tmux-mirror-cwd-process nil)))
+                   (enkan-repl--terminal-tmux--mirror-rename-for-cwd
+                    target-buffer target-id cwd)))))))))
+
+(defun enkan-repl--terminal-tmux--tail-append (content chunk max-chars)
+  "Append CHUNK to CONTENT, keeping at most MAX-CHARS characters.
+When MAX-CHARS is nil or non-positive, return the full concatenation."
+  (if (and (integerp max-chars) (> max-chars 0))
+      (cond
+       ((>= (length chunk) max-chars)
+        (substring chunk (- max-chars)))
+       (t
+        (let ((combined (concat content chunk)))
+          (if (> (length combined) max-chars)
+              (substring combined (- max-chars))
+            combined))))
+    (concat content chunk)))
+
+(defun enkan-repl--terminal-tmux--tail-lines (content max-lines)
+  "Return CONTENT limited to its final MAX-LINES lines."
+  (if (and (integerp max-lines) (> max-lines 0))
+      (let* ((lines (split-string content "\n"))
+             (count (length lines)))
+        (string-join
+         (if (> count max-lines)
+             (last lines max-lines)
+           lines)
+         "\n"))
+    content))
+
+(defun enkan-repl--terminal-tmux--max-line-length ()
+  "Return the configured mirror line length limit, or nil."
+  (and (integerp enkan-repl-tmux-mirror-max-line-length)
+       (> enkan-repl-tmux-mirror-max-line-length 0)
+       enkan-repl-tmux-mirror-max-line-length))
+
+(defun enkan-repl--terminal-tmux--truncate-line (line max-length)
+  "Return LINE shortened to MAX-LENGTH characters when needed."
+  (if (and max-length (> (length line) max-length))
+      (format "%s [enkan-repl: omitted %d chars]"
+              (substring line 0 max-length)
+              (- (length line) max-length))
+    line))
+
+(defun enkan-repl--terminal-tmux--noisy-line-p (line)
+  "Return non-nil when LINE looks like generated diff/code noise."
+  (let ((max-length (enkan-repl--terminal-tmux--max-line-length)))
+    (or (and max-length
+             (> (length line) max-length))
+        (string-match-p
+         (rx string-start (* space)
+             (or "diff --git" "index " "@@ " "+++ " "--- "
+                 "```" "~~~"))
+         line)
+        (string-match-p
+         (rx string-start (* space) (or "+" "-")
+             (not (any "\n")))
+         line))))
+
+(defun enkan-repl--terminal-tmux--noisy-block-threshold ()
+  "Return the configured noisy block threshold."
+  (if (and (integerp enkan-repl-tmux-mirror-noisy-block-threshold)
+           (> enkan-repl-tmux-mirror-noisy-block-threshold 0))
+      enkan-repl-tmux-mirror-noisy-block-threshold
+    6))
+
+(defun enkan-repl--terminal-tmux--flush-noisy-lines (lines output)
+  "Append compacted or verbatim noisy LINES to OUTPUT."
+  (let ((threshold (enkan-repl--terminal-tmux--noisy-block-threshold)))
+    (if (>= (length lines) threshold)
+        (cons (format "[enkan-repl: omitted %d noisy/diff line(s)]"
+                      (length lines))
+              output)
+      (append lines output))))
+
+(defun enkan-repl--terminal-tmux--compact-noisy-content (content)
+  "Collapse large noisy blocks in CONTENT."
+  (if (not enkan-repl-tmux-mirror-compact-noisy-blocks)
+      content
+    (let ((output nil)
+          (noisy nil)
+          (max-length (enkan-repl--terminal-tmux--max-line-length)))
+      (dolist (line (split-string content "\n"))
+        (if (enkan-repl--terminal-tmux--noisy-line-p line)
+            (push (enkan-repl--terminal-tmux--truncate-line line max-length)
+                  noisy)
+          (let ((line (enkan-repl--terminal-tmux--truncate-line
+                       line max-length)))
+            (when noisy
+              (setq output
+                    (enkan-repl--terminal-tmux--flush-noisy-lines
+                     noisy output))
+              (setq noisy nil))
+            (push line output))))
+      (when noisy
+        (setq output
+              (enkan-repl--terminal-tmux--flush-noisy-lines noisy output)))
+      (string-join (reverse output) "\n"))))
+
+(defun enkan-repl--terminal-tmux--prepare-mirror-content (content)
+  "Return bounded, display-ready tmux mirror CONTENT."
+  (let* ((max-chars (and (integerp enkan-repl-tmux-mirror-max-chars)
+                         (> enkan-repl-tmux-mirror-max-chars 0)
+                         enkan-repl-tmux-mirror-max-chars))
+         (content (if (and max-chars
+                           (> (length content) max-chars))
+                      (substring content (- max-chars))
+                    content)))
+    (setq content (enkan-repl--terminal-tmux--compact-noisy-content content))
+    (setq content
+          (enkan-repl--terminal-tmux--tail-lines
+           content enkan-repl-tmux-mirror-display-lines))
+    (if (and max-chars (> (length content) max-chars))
+        (substring content (- max-chars))
+      content)))
 
 (defun enkan-repl--terminal-tmux--capture-pane-async (id lines callback)
   "Capture tmux ID asynchronously and call CALLBACK with content and status.
@@ -622,30 +1258,53 @@ LINES is the maximum scrollback to include.  CALLBACK receives two
 arguments: CONTENT, or nil on failure, and the tmux process exit status."
   (unless (executable-find enkan-repl-tmux-executable)
     (user-error "Tmux executable not found: %s" enkan-repl-tmux-executable))
-  (let* ((capture-buffer (generate-new-buffer " *enkan-repl tmux async capture*"))
-         (command (list enkan-repl-tmux-executable
+  (let* ((command (list enkan-repl-tmux-executable
                         "capture-pane" "-p" "-J" "-S"
                         (format "-%d" (max 0 lines))
-                        "-t" id)))
-    (make-process
-     :name (format "enkan-tmux-capture %s" id)
-     :buffer capture-buffer
-     :command command
-     :connection-type 'pipe
-     :noquery t
-     :sentinel
-     (lambda (process _event)
-       (when (memq (process-status process) '(exit signal))
-         (let ((status (process-exit-status process))
-               (content (when (buffer-live-p capture-buffer)
-                          (with-current-buffer capture-buffer
-                            (buffer-substring-no-properties
-                             (point-min) (point-max))))))
-           (when (buffer-live-p capture-buffer)
-             (kill-buffer capture-buffer))
-           (funcall callback
-                    (and (zerop status) content)
-                    status)))))))
+                        "-t" id))
+         (max-chars (and (integerp enkan-repl-tmux-mirror-max-chars)
+                         (> enkan-repl-tmux-mirror-max-chars 0)
+                         enkan-repl-tmux-mirror-max-chars))
+         (content "")
+         (done nil)
+         timer
+         process)
+    (cl-labels
+        ((finish
+          (status)
+          (unless done
+            (setq done t)
+            (when timer
+              (cancel-timer timer)
+              (setq timer nil))
+            (funcall callback
+                     (and (integerp status) (zerop status) content)
+                     status))))
+      (setq process
+            (make-process
+             :name (format "enkan-tmux-capture %s" id)
+             :buffer nil
+             :command command
+             :connection-type 'pipe
+             :noquery t
+             :filter (lambda (_process chunk)
+                       (setq content
+                             (enkan-repl--terminal-tmux--tail-append
+                              content chunk max-chars)))
+             :sentinel (lambda (proc _event)
+                         (when (memq (process-status proc) '(exit signal))
+                           (finish (process-exit-status proc))))))
+      (when (and (numberp enkan-repl-tmux-mirror-capture-timeout)
+                 (> enkan-repl-tmux-mirror-capture-timeout 0))
+        (setq timer
+              (run-at-time
+               enkan-repl-tmux-mirror-capture-timeout nil
+               (lambda ()
+                 (unless done
+                   (finish 'timeout)
+                   (when (process-live-p process)
+                     (delete-process process)))))))
+      process)))
 
 (defun enkan-repl--terminal-tmux--mirror-mark-closed ()
   "Mark current tmux mirror buffer as closed."
@@ -659,14 +1318,19 @@ arguments: CONTENT, or nil on failure, and the tmux process exit status."
     (buffer id started content status)
   "Apply async tmux capture CONTENT to BUFFER for ID.
 STARTED is the capture start time.  STATUS is the tmux process exit status."
-  (ignore status)
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (when (equal enkan-repl--tmux-mirror-id id)
         (setq enkan-repl--tmux-mirror-refresh-process nil)
-        (if (null content)
-            (enkan-repl--terminal-tmux--mirror-mark-closed)
-          (let* ((content-hash (secure-hash 'sha1 content))
+        (cond
+         ((eq status 'timeout)
+          (enkan-repl--terminal-tmux--mirror-set-state 'timed-out))
+         ((null content)
+          (enkan-repl--terminal-tmux--mirror-mark-closed))
+         (t
+          (let* ((content
+                  (enkan-repl--terminal-tmux--prepare-mirror-content content))
+                 (content-hash (secure-hash 'sha1 content))
                  (window-state (enkan-repl--terminal-tmux--mirror-window-state
                                 buffer))
                  (inhibit-read-only t))
@@ -683,7 +1347,7 @@ STARTED is the capture start time.  STATUS is the tmux process exit status."
               (enkan-repl--terminal-tmux--replace-mirror-content content)
               (enkan-repl--terminal-tmux--restore-window-state
                buffer window-state)
-              (enkan-repl--terminal-tmux--mirror-set-state 'fresh))))))))
+              (enkan-repl--terminal-tmux--mirror-set-state 'fresh)))))))))
 
 (defun enkan-repl--terminal-tmux--mirror-refresh (buffer &optional force)
   "Refresh mirror BUFFER by capturing current tmux pane content.
@@ -728,24 +1392,61 @@ When FORCE is non-nil, refresh even when BUFFER is hidden."
         (cancel-timer enkan-repl--tmux-mirror-timer)
         (setq enkan-repl--tmux-mirror-timer nil)))))
 
-(defun enkan-repl--terminal-tmux--mirror-make (id &optional defer-refresh)
-  "Get or create the mirror buffer for tmux ID, set up timer, return it.
-When DEFER-REFRESH is non-nil, do not immediately refresh the mirror content."
-  (let ((buf (get-buffer-create
-              (enkan-repl--terminal-tmux--mirror-buffer-name id))))
+;;;###autoload
+(defun enkan-repl-tmux-stop-all-mirrors (&optional kill-buffers)
+  "Stop all tmux mirror timers and in-flight mirror processes.
+With prefix KILL-BUFFERS, also kill the mirror buffers.  This command does not
+call tmux; it only quiets Emacs-side timers and subprocess sentinels."
+  (interactive "P")
+  (let ((count 0))
+    (dolist (buffer (buffer-list))
+      (when (and (buffer-live-p buffer)
+                 (buffer-local-boundp 'enkan-repl--tmux-mirror-id buffer)
+                 (buffer-local-value 'enkan-repl--tmux-mirror-id buffer))
+        (setq count (1+ count))
+        (with-current-buffer buffer
+          (enkan-repl--terminal-tmux--mirror-stop buffer)
+          (when (and enkan-repl--tmux-mirror-refresh-process
+                     (process-live-p enkan-repl--tmux-mirror-refresh-process))
+            (delete-process enkan-repl--tmux-mirror-refresh-process))
+          (setq enkan-repl--tmux-mirror-refresh-process nil)
+          (when (and enkan-repl--tmux-mirror-cwd-process
+                     (process-live-p enkan-repl--tmux-mirror-cwd-process))
+            (delete-process enkan-repl--tmux-mirror-cwd-process))
+          (setq enkan-repl--tmux-mirror-cwd-process nil)
+          (enkan-repl--terminal-tmux--mirror-set-state 'stopped))
+        (when kill-buffers
+          (kill-buffer buffer))))
+    (message "Stopped %d tmux mirror buffer(s)" count)
+    count))
+
+(defun enkan-repl--terminal-tmux--mirror-make (id &optional defer-refresh path)
+  "Get or create the mirror buffer for tmux ID and return it.
+When tmux mirror auto-refresh is enabled and DEFER-REFRESH is nil, start a
+timer and immediately refresh the mirror content.  With the default settings,
+mirror buffers never refresh unless explicitly requested.
+When PATH is non-nil, use it for the eat-compatible buffer name.  Otherwise
+create the buffer without blocking on tmux cwd lookup and rename it later when
+the asynchronous lookup returns."
+  (let ((buf (or (enkan-repl--terminal-tmux--find-mirror-buffer id)
+                 (get-buffer-create
+                  (enkan-repl--terminal-tmux--mirror-buffer-name id path)))))
+    (enkan-repl--terminal-tmux--ensure-bell-monitor)
     (with-current-buffer buf
       (unless (derived-mode-p 'enkan-repl-tmux-mirror-mode)
         (enkan-repl-tmux-mirror-mode))
       (setq enkan-repl--tmux-mirror-id id)
       (enkan-repl--terminal-tmux--mirror-update-status)
-      (unless enkan-repl--tmux-mirror-timer
+      (unless path
+        (enkan-repl--terminal-tmux--mirror-start-cwd-lookup buf id))
+      (when (and (enkan-repl--terminal-tmux--mirror-auto-refresh-enabled-p)
+                 (not enkan-repl--tmux-mirror-timer))
         (setq enkan-repl--tmux-mirror-timer
               (run-with-idle-timer
                enkan-repl-tmux-mirror-interval t
                #'enkan-repl--terminal-tmux--mirror-refresh buf)))
-      ;; First refresh immediately for instant feedback when visible.  Hidden
-      ;; mirrors stay cheap until manually refreshed or displayed.
-      (unless defer-refresh
+      (when (and (enkan-repl--terminal-tmux--mirror-auto-refresh-enabled-p)
+                 (not defer-refresh))
         (enkan-repl--terminal-tmux--mirror-refresh buf))
       ;; Stop the timer when buffer is killed.
       (add-hook 'kill-buffer-hook
@@ -767,7 +1468,7 @@ externally via `enkan-repl-tmux-attach'."
    (t
     (let ((buf (enkan-repl--terminal-tmux--mirror-make id t)))
       (pop-to-buffer-same-window buf)
-      (enkan-repl--terminal-tmux--mirror-refresh buf t)
+      (message "tmux mirror displayed; press g or run M-x enkan-repl-tmux-refresh-current to refresh")
       buf))))
 
 ;;;###autoload

--- a/enkan-repl-utils.el
+++ b/enkan-repl-utils.el
@@ -25,6 +25,8 @@
 ;; require to keep the dependency graph one-directional and to allow
 ;; loading this file standalone in tests.
 (declare-function enkan-repl--terminal-tmux-alive-p "enkan-repl-terminal" (id))
+(declare-function enkan-repl--terminal-tmux-mirror-buffer-alive-p
+                  "enkan-repl-terminal" (buffer))
 (defvar enkan-repl--tmux-mirror-id)
 
 ;;;; Buffer Name API (New - Compatibility Mode)
@@ -99,8 +101,9 @@ Backend-agnostic check, in priority order:
 1. BUFFER's buffer-local `eat--process' is a live process (kephale eat).
 2. BUFFER has a live OS process attached via `get-buffer-process'
    (akib eat / general).
-3. BUFFER is a tmux mirror carrying buffer-local
-   `enkan-repl--tmux-mirror-id' and the underlying tmux pane is alive."
+3. BUFFER is an open tmux mirror carrying buffer-local
+   `enkan-repl--tmux-mirror-id'.  This path intentionally avoids synchronous
+   tmux liveness checks while scanning `buffer-list'."
   (and (bufferp buffer)
        (buffer-live-p buffer)
        (or
@@ -112,11 +115,12 @@ Backend-agnostic check, in priority order:
         ;; (2) general: live process attached to the buffer
         (let ((proc (get-buffer-process buffer)))
           (and proc (process-live-p proc)))
-        ;; (3) tmux mirror buffer with bound id pointing at live pane
-        (let ((id (buffer-local-value
-                   'enkan-repl--tmux-mirror-id buffer)))
-          (and id (fboundp 'enkan-repl--terminal-tmux-alive-p)
-               (enkan-repl--terminal-tmux-alive-p id))))))
+        ;; (3) tmux mirror buffer.  Do not synchronously call tmux here;
+        ;; this predicate is used inside buffer-list scans and completion
+        ;; paths where blocking the main thread is worse than keeping a
+        ;; stale mirror until the next async refresh marks it closed.
+        (and (fboundp 'enkan-repl--terminal-tmux-mirror-buffer-alive-p)
+             (enkan-repl--terminal-tmux-mirror-buffer-alive-p buffer)))))
 
 (defun enkan-repl--get-workspace-buffer-count-pure (buffer-list workspace-id)
   "Pure function to count live terminal sessions for WORKSPACE-ID.
@@ -449,7 +453,6 @@ Returns a list of plists, each containing :name, :args, :docstring,
               ;; Look for (interactive) in the function body
               ;; Only search until we find another defun or end of reasonable function scope
               (let ((body-idx (1+ current-line))
-                    (paren-count 0)
                     (in-function t))
                 (while (and (< body-idx (length lines))
                             (not interactive-p)
@@ -593,7 +596,8 @@ Returns formatted string."
 (defun enkan-repl-utils--encode-full-path (path prefix separator)
   "Encode PATH with PREFIX and SEPARATOR (pure).
 Returns string like PREFIX + PATH with '/' replaced by SEPARATOR.
-Example: PATH '/Users/proj', PREFIX 'enkan', SEP '--' -> 'enkan--Users--proj'"
+Example: PATH \='/Users/proj', PREFIX \='enkan', SEP \='--'
+returns \='enkan--Users--proj'."
   (let* ((expanded-path (expand-file-name path))
          (cleaned-path (if (string-suffix-p "/" expanded-path)
                            (substring expanded-path 0 -1)
@@ -603,7 +607,7 @@ Example: PATH '/Users/proj', PREFIX 'enkan', SEP '--' -> 'enkan--Users--proj'"
 (defun enkan-repl-utils--decode-full-path (encoded-name prefix separator)
   "Decode ENCODED-NAME using PREFIX and SEPARATOR (pure).
 Returns normalized directory path ending with '/'.
-Example: 'enkan--Users--proj' -> '/Users/proj/'"
+Example: \='enkan--Users--proj' returns \='/Users/proj/'."
   (when (string-prefix-p prefix encoded-name)
     (let ((path-part (substring encoded-name (length prefix))))
       (concat (replace-regexp-in-string (regexp-quote separator) "/" path-part) "/"))))

--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -43,7 +43,7 @@
 ;; - File path support for AI tool direct reading
 ;;
 ;; Quick Start:
-;;   M-x enkan-repl-start-eat
+;;   M-x enkan-repl-start-session
 ;;   M-x enkan-repl-open-project-input-file
 ;;
 ;; This package builds upon eat terminal emulator.  We extend our deepest
@@ -52,6 +52,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 
 ;; Load horizontal menu interface if available (avoid compile-time hard fail)
 (when (locate-library "hmenu")
@@ -72,7 +73,8 @@
   ;; in-memory state, even when individual operations skipped the mirror.
   (add-hook 'kill-emacs-hook
             (lambda ()
-              (ignore-errors (enkan-repl-state-save)))))
+              (unless noninteractive
+                (ignore-errors (enkan-repl-state-save))))))
 
 ;; Load workspace management functions
 (when (locate-library "enkan-repl-workspace")
@@ -98,11 +100,15 @@
 (declare-function enkan-repl--buffer-matches-directory "enkan-repl-utils" (buffer-name target-directory &optional instance))
 (declare-function enkan-repl--buffer-alive-as-terminal-p "enkan-repl-utils" (buffer))
 (declare-function enkan-repl--terminal-tmux-alive-p "enkan-repl-terminal" (id))
-(declare-function enkan-repl--terminal-tmux--mirror-make "enkan-repl-terminal" (id &optional defer-refresh))
+(declare-function enkan-repl--terminal-tmux-mirror-buffer-alive-p "enkan-repl-terminal" (buffer))
+(declare-function enkan-repl--terminal-tmux--mirror-make "enkan-repl-terminal" (id &optional defer-refresh path))
+(declare-function enkan-repl--terminal-tmux--list-windows "enkan-repl-terminal" (session))
+(declare-function enkan-repl--terminal-tmux--make-id "enkan-repl-terminal" (session window))
 (declare-function enkan-repl--terminal-tmux-kill-workspace "enkan-repl-terminal" (workspace-id))
 (declare-function enkan-repl-tmux-refresh-workspace "enkan-repl-terminal" (&optional quiet))
 (defvar enkan-repl--tmux-mirror-id)
 (defvar enkan-repl-terminal-backend)
+(defvar enkan-repl-tmux-session-prefix)
 (declare-function enkan-repl--session-entry-project "enkan-repl-utils" (entry-value))
 (declare-function enkan-repl--session-entry-instance "enkan-repl-utils" (entry-value))
 (declare-function enkan-repl--make-session-entry-value "enkan-repl-utils" (project-name &optional instance))
@@ -115,7 +121,9 @@
 (declare-function enkan-repl--terminal-kill "enkan-repl-terminal" (id))
 (declare-function enkan-repl--terminal-display "enkan-repl-terminal" (id))
 (declare-function enkan-repl--terminal-id-instance "enkan-repl-terminal" (id))
+(declare-function enkan-repl-state-load "enkan-repl-state" (&optional file))
 (declare-function enkan-repl-state-save "enkan-repl-state" (&optional file))
+(declare-function enkan-repl-state--list-live-tmux-sessions "enkan-repl-state" (prefix))
 (declare-function enkan-repl-state-tmux-reconcile "enkan-repl-state" (&optional file))
 (declare-function enkan-repl--extract-project-name "enkan-repl-utils" (buffer-name-or-path))
 (declare-function enkan-repl--is-enkan-buffer-name "enkan-repl-utils" (name))
@@ -440,6 +448,86 @@ Returns the loaded plist, or nil if no state was found."
        (string= current-id enkan-repl--current-workspace)
        (equal loaded-workspaces enkan-repl--workspaces)))
 
+(defun enkan-repl--tmux-reattach-workspace-id (session)
+  "Return workspace id encoded in tmux SESSION, or nil."
+  (let ((prefix enkan-repl-tmux-session-prefix))
+    (when (and (stringp session)
+               (string-prefix-p prefix session)
+               (> (length session) (length prefix)))
+      (substring session (length prefix)))))
+
+(defun enkan-repl--tmux-reattach-project-name (window)
+  "Infer a project name from tmux WINDOW."
+  (let ((name (if (and (stringp window)
+                       (not (string-empty-p window)))
+                  window
+                "tmux")))
+    (if (string-match "\\`\\(.+\\)-[0-9]+\\'" name)
+        (match-string 1 name)
+      name)))
+
+(defun enkan-repl--tmux-reattach-state-from-session (session)
+  "Build a minimal workspace plist from live tmux SESSION.
+This intentionally uses tmux window names only.  Pane cwd lookup is not
+performed here because that would add synchronous tmux calls to reattach."
+  (let ((windows (enkan-repl--terminal-tmux--list-windows session))
+        (counter 0)
+        session-list
+        aliases
+        current-project)
+    (dolist (window windows)
+      (let* ((id (enkan-repl--terminal-tmux--make-id session window))
+             (project (enkan-repl--tmux-reattach-project-name window))
+             (instance (enkan-repl--terminal-id-instance id)))
+        (setq counter (1+ counter))
+        (unless current-project
+          (setq current-project project))
+        (push (cons counter
+                    (enkan-repl--make-session-entry-value project instance))
+              session-list)
+        (unless (assoc project aliases)
+          (push (cons project project) aliases))))
+    (list :current-project current-project
+          :session-list (nreverse session-list)
+          :session-counter counter
+          :project-aliases (nreverse aliases))))
+
+(defun enkan-repl--tmux-reattach-live-workspaces ()
+  "Return live tmux workspaces as an alist of (WORKSPACE-ID . STATE)."
+  (let ((sessions (enkan-repl-state--list-live-tmux-sessions
+                   enkan-repl-tmux-session-prefix))
+        workspaces)
+    (dolist (session sessions)
+      (let ((workspace-id (enkan-repl--tmux-reattach-workspace-id session)))
+        (when workspace-id
+          (push (cons workspace-id
+                      (enkan-repl--tmux-reattach-state-from-session session))
+                workspaces))))
+    (nreverse workspaces)))
+
+(defun enkan-repl--tmux-reattach-merge-workspaces (persisted live)
+  "Merge PERSISTED and LIVE workspace alists.
+Live tmux sessions define the set of restored workspaces.  Persisted state wins
+for a live workspace when it exists; otherwise a minimal live-derived state is
+used."
+  (let (merged imported restored dropped)
+    (dolist (live-entry live)
+      (let* ((workspace-id (car live-entry))
+             (persisted-entry (assoc workspace-id persisted #'string=)))
+        (push workspace-id restored)
+        (if persisted-entry
+            (push (cons workspace-id (copy-tree (cdr persisted-entry)))
+                  merged)
+          (push workspace-id imported)
+          (push (copy-tree live-entry) merged))))
+    (dolist (persisted-entry persisted)
+      (unless (assoc (car persisted-entry) live #'string=)
+        (push (car persisted-entry) dropped)))
+    (list :loaded-workspaces (nreverse merged)
+          :restored (nreverse restored)
+          :imported (nreverse imported)
+          :dropped (nreverse dropped))))
+
 (defun enkan-repl--tmux-ensure-restored-workspaces (workspace-ids)
   "Ensure tmux mirror buffers exist for WORKSPACE-IDS without force-refreshing.
 Returns the total number of mirror buffers ensured."
@@ -455,23 +543,29 @@ Returns the total number of mirror buffers ensured."
 
 ;;;###autoload
 (defun enkan-repl-tmux-reattach (&optional file)
-  "Reconnect Emacs state to live tmux sessions using persisted workspace state.
-FILE defaults to `enkan-repl-state-file'.  The command reconciles the saved
-workspace state with live tmux sessions, restores the matching workspaces,
-selects the saved current workspace when possible, and recreates tmux mirror
-buffers for the restored workspaces.
+  "Reconnect Emacs state to live tmux sessions.
+FILE defaults to `enkan-repl-state-file'.  Live tmux sessions whose names start
+with `enkan-repl-tmux-session-prefix' define the workspaces to restore.  When a
+matching persisted workspace exists, its saved state is reused.  When no saved
+state exists for a live tmux session, a minimal workspace is imported from the
+tmux session's windows so reattach works after Emacs state was lost.
 
 This command is intentionally manual; enkan-repl does not reattach on load."
   (interactive)
   (unless (eq enkan-repl-terminal-backend 'tmux)
     (user-error "Current terminal backend is not tmux: %S"
                 enkan-repl-terminal-backend))
-  (unless (fboundp 'enkan-repl-state-tmux-reconcile)
+  (unless (and (fboundp 'enkan-repl-state-load)
+               (fboundp 'enkan-repl-state--list-live-tmux-sessions))
     (user-error "Enkan-repl-state is not loaded"))
-  (let* ((result (enkan-repl-state-tmux-reconcile file))
+  (let* ((payload (enkan-repl-state-load file))
+         (persisted-workspaces (plist-get payload :workspaces))
+         (live-workspaces (enkan-repl--tmux-reattach-live-workspaces))
+         (result (enkan-repl--tmux-reattach-merge-workspaces
+                  persisted-workspaces live-workspaces))
          (loaded-workspaces (plist-get result :loaded-workspaces))
          (restored-ids (plist-get result :restored))
-         (saved-current (plist-get result :current))
+         (saved-current (plist-get payload :current))
          (current-id (cond
                       ((and saved-current
                             (member saved-current restored-ids))
@@ -480,10 +574,8 @@ This command is intentionally manual; enkan-repl does not reattach on load."
                             (member enkan-repl--current-workspace restored-ids))
                        enkan-repl--current-workspace)
                       (t (car restored-ids)))))
-    (unless result
-      (user-error "No persisted enkan-repl state was loaded"))
     (unless loaded-workspaces
-      (user-error "No persisted workspace matched a live tmux session"))
+      (user-error "No live enkan tmux sessions found"))
     (if (enkan-repl--tmux-reattach-already-current-p
          loaded-workspaces current-id)
         (progn
@@ -504,15 +596,15 @@ This command is intentionally manual; enkan-repl does not reattach on load."
          (length loaded-workspaces)
          ensured
          (let ((dropped (plist-get result :dropped))
-               (orphans (plist-get result :orphan-tmux)))
+               (imported (plist-get result :imported)))
            (concat
+            (if imported
+                (format ", imported live tmux: %s"
+                        (mapconcat #'identity imported ", "))
+              "")
             (if dropped
                 (format ", dropped state-only: %s"
                         (mapconcat #'identity dropped ", "))
-              "")
-            (if orphans
-                (format ", ignored orphan tmux: %s"
-                        (mapconcat #'identity orphans ", "))
               ""))))
         result))))
 
@@ -707,11 +799,11 @@ Returns the template path to use, or nil to use default template."
                (insert "- ~M-x enkan-repl-send-3~ - Send '3' for numbered choice prompts\n")
                (insert "- ~M-x enkan-repl-send-escape~ - Send ESC key to interrupt operations\n")
                (insert "- ~M-x enkan-repl-open-project-input-file~ - Open or create project input file\n")
-               (insert "- ~M-x enkan-repl-start-eat~ - Start eat terminal session\n")
+               (insert "- ~M-x enkan-repl-start-session~ - Start terminal session\n")
                (insert "- ~M-x enkan-repl-setup~ - Set up convenient window layout\n")
                (insert "\n** Working Notes\n")
                (insert "Write your thoughts and notes here.\n")
-               (insert "Send specific parts to a eat buffer using the commands above.\n"))
+               (insert "Send specific parts to a terminal session using the commands above.\n"))
              (message "Created new template file: %s" template-path)
              template-path)))
         (?q
@@ -786,18 +878,18 @@ Returns categorized functions as string, or falls back to static list."
   (concat "** Command Palette\n\n"
           "- ~M-x enkan-repl-cheat-sheet~ - Display interactive cheat-sheet for enkan-repl commands.\n\n"
           "** Text Sender\n\n"
-          "- ~M-x enkan-repl-send-region~ - Send the text in region from START to END to eat session.\n"
-          "- ~M-x enkan-repl-send-buffer~ - Send the entire current buffer to eat session.\n"
-          "- ~M-x enkan-repl-send-rest-of-buffer~ - Send rest of buffer from cursor position to end to eat session.\n"
-          "- ~M-x enkan-repl-send-line~ - Send the current line to eat session.\n"
-          "- ~M-x enkan-repl-send-enter~ - Send enter key to eat session buffer.\n"
-          "- ~M-x enkan-repl-send-1~ - Send \\='1\\=' to eat session buffer for numbered choice prompts.\n"
-          "- ~M-x enkan-repl-send-2~ - Send \\='2\\=' to eat session buffer for numbered choice prompts.\n"
-          "- ~M-x enkan-repl-send-3~ - Send \\='3\\=' to eat session buffer for numbered choice prompts.\n"
-          "- ~M-x enkan-repl-send-escape~ - Send ESC key to eat session buffer.\n\n"
+          "- ~M-x enkan-repl-send-region~ - Send the text in region from START to END to terminal session.\n"
+          "- ~M-x enkan-repl-send-buffer~ - Send the entire current buffer to terminal session.\n"
+          "- ~M-x enkan-repl-send-rest-of-buffer~ - Send rest of buffer from cursor position to end to terminal session.\n"
+          "- ~M-x enkan-repl-send-line~ - Send the current line to terminal session.\n"
+          "- ~M-x enkan-repl-send-enter~ - Send enter key to terminal session buffer.\n"
+          "- ~M-x enkan-repl-send-1~ - Send \\='1\\=' to terminal session buffer for numbered choice prompts.\n"
+          "- ~M-x enkan-repl-send-2~ - Send \\='2\\=' to terminal session buffer for numbered choice prompts.\n"
+          "- ~M-x enkan-repl-send-3~ - Send \\='3\\=' to terminal session buffer for numbered choice prompts.\n"
+          "- ~M-x enkan-repl-send-escape~ - Send ESC key to terminal session buffer.\n\n"
           "** Session Controller\n\n"
-          "- ~M-x enkan-repl-start-eat~ - Start eat terminal and change to appropriate directory.\n"
-          "- ~M-x enkan-repl-setup~ - Set up window layout with org file on left and eat on right.\n\n"
+          "- ~M-x enkan-repl-start-session~ - Start terminal session in the current directory.\n"
+          "- ~M-x enkan-repl-setup~ - Set up window layout with org file on left and terminal on right.\n\n"
           "** Utilities\n\n"
           "- ~M-x enkan-repl-open-project-input-file~ - Open or create project input file for current directory.\n"
           "- ~M-x enkan-repl-status~ - Show detailed diagnostic information for troubleshooting connection issues.\n"))
@@ -876,7 +968,7 @@ Returns: Directory path or nil"
             (enkan-repl--buffer-name->path (buffer-name))))))))
 
 (defun enkan-repl--get-buffer-for-directory (&optional directory instance)
-  "Get the eat buffer for DIRECTORY if it exists and is live.
+  "Get the terminal buffer for DIRECTORY if it exists and is live.
 If DIRECTORY is nil, use current `default-directory'.
 If INSTANCE is non-nil (an integer), match only the buffer whose
 multi-instance index equals INSTANCE; otherwise return the first
@@ -916,8 +1008,8 @@ Only returns buffers that belong to the current workspace."
 ;;;; Send Functions - Internal Helpers
 
 (defun enkan-repl--can-send-text (&optional directory)
-  "Check if text can actually be sent to eat session (strict check).
-If DIRECTORY is provided, check for eat session in that directory.
+  "Check if text can actually be sent to terminal session (strict check).
+If DIRECTORY is provided, check for a terminal session in that directory.
 Otherwise, use current `default-directory'.
 Falls back to `get-buffer-process' when `eat--process' is unbound or nil."
   (let ((session-buffer (enkan-repl--get-buffer-for-directory directory)))
@@ -1126,24 +1218,21 @@ RESTART-FUNC is a zero-argument function to call for restart.
     (kill-buffer existing-buffer)
     (if restart-func
         (funcall restart-func)
-      (message "Removed dead eat session buffer in: %s" target-dir))))
+      (message "Removed dead terminal session buffer in: %s" target-dir))))
 
-;;;###autoload
-(defun enkan-repl-start-eat (&optional _force)
+(defun enkan-repl--start-session (&optional _force)
   "Start a terminal session in current directory via the configured backend.
 FORCE parameter ignored - always starts a new session.
 
 Dispatches to `enkan-repl--terminal-start' so the active backend (eat or
 tmux, per `enkan-repl-terminal-backend') decides how to spawn the
-session.  The function name is kept for backward compatibility; the body
-no longer assumes eat specifically.
+session.
 
 For the tmux backend, an Emacs-side mirror buffer is created eagerly so
 that layout / lookup code (which iterates over `buffer-list') can find
 the session even though the actual terminal lives outside Emacs.
 
 Category: Session Controller"
-  (interactive)
   (let* ((target-dir default-directory)
          (term-id (enkan-repl--terminal-start target-dir))
          (instance (when term-id
@@ -1155,7 +1244,7 @@ Category: Session Controller"
       (when (and (eq enkan-repl-terminal-backend 'tmux)
                  (fboundp 'enkan-repl--terminal-tmux--mirror-make))
         (ignore-errors
-          (enkan-repl--terminal-tmux--mirror-make term-id)))
+          (enkan-repl--terminal-tmux--mirror-make term-id nil target-dir)))
       ;; Register session and save workspace state.  Multi-instance index
       ;; is captured so the same project can be tracked across distinct
       ;; instances.
@@ -1166,7 +1255,19 @@ Category: Session Controller"
          enkan-repl--current-project
          instance)
         (enkan-repl--save-workspace-state))
-      (message "Started eat session in: %s" target-dir))))
+      (message "Started terminal session in: %s" target-dir))))
+
+;;;###autoload
+(defun enkan-repl-start-session (&optional force)
+  "Start a terminal session in the current directory.
+This is the backend-neutral session starter.  It works with both the eat and
+tmux terminal backends configured by `enkan-repl-terminal-backend'.
+FORCE is accepted for interactive compatibility and currently ignored;
+the command always starts a new session.
+
+Category: Session Controller"
+  (interactive "P")
+  (enkan-repl--start-session force))
 
 (defun enkan-repl--is-standard-file-path (file-path directory-name)
   "Check if FILE-PATH is a standard input file for DIRECTORY-NAME."
@@ -1222,10 +1323,10 @@ COUNTER: session counter"
       (princ (format "🔧 Setup project aliases (enkan-repl-project-aliases): %s\n\n" (enkan-repl--ws-project-aliases))))))
 
 (defun enkan-repl--setup-start-sessions (alias-list buffer-name)
-  "Start eat sessions for each alias in ALIAS-LIST and log to BUFFER-NAME.
+  "Start terminal sessions for each alias in ALIAS-LIST and log to BUFFER-NAME.
 Includes error handling for individual session failures."
   (with-current-buffer buffer-name
-    (princ "🚀 Starting eat sessions:\n"))
+    (princ "🚀 Starting terminal sessions:\n"))
   (let ((session-number 1)
         (success-count 0)
         (failure-count 0))
@@ -1236,8 +1337,8 @@ Includes error handling for individual session failures."
                   (default-directory (expand-file-name (cdr project-info))))
               ;; Register session
               (enkan-repl--register-session session-number project-name)
-              ;; Start eat session in current directory (force restart if needed)
-              (enkan-repl-start-eat t)
+              ;; Start terminal session in current directory.
+              (enkan-repl-start-session t)
               (with-current-buffer buffer-name
                 (princ (format "  ✅ Session %d: %s (%s) - SUCCESS\n" session-number alias project-name)))
               (setq success-count (1+ success-count))))
@@ -1263,8 +1364,8 @@ Implemented as pure function, side effects are handled by upper functions."
 (defun enkan-repl-setup ()
   "Set up window layout based on context.
 - Standard input file: basic window layout with project input file on
-  left and eat session on right in current workspace
-- Center file: auto start eat sessions using project configuration
+  left and terminal session on right in current workspace
+- Center file: auto start terminal sessions using project configuration
   in current workspace
 
 Category: Session Controller"
@@ -1275,13 +1376,13 @@ Category: Session Controller"
     (if is-standard-file
         ;; Standard input file mode: simple window layout
         (progn
-          ;; Create workspace with project BEFORE starting eat session
+          ;; Create workspace with project before starting terminal session.
           (enkan-repl--setup-create-workspace-with-project t nil)
           (delete-other-windows)
           (split-window-right)
-          ;; Move to right window and start eat session
+          ;; Move to right window and start terminal session
           (other-window 1)
-          (enkan-repl-start-eat)
+          (enkan-repl-start-session)
           ;; Move back to left window and open project input file
           (other-window -1)
           (enkan-repl-open-project-input-file)
@@ -1400,7 +1501,10 @@ Category: Command Palette"
   "Rebuild `enkan-repl-global-minor-mode-map'.
 Uses `enkan-repl-global-minor-bindings' as source."
   (setq enkan-repl-global-minor-mode-map
-        (enkan-repl--build-map enkan-repl-global-minor-bindings)))
+        (enkan-repl--build-map enkan-repl-global-minor-bindings))
+  (when-let ((entry (assq 'enkan-repl-global-minor-mode
+                          minor-mode-map-alist)))
+    (setcdr entry enkan-repl-global-minor-mode-map)))
 
 ;; 初期構築
 (enkan-repl--refresh-global-minor-map)
@@ -1435,12 +1539,21 @@ When enabled, some keybindings are available across all buffers."
 (defun enkan-repl--get-project-paths-for-current (current-project projects target-directories)
   "Get project paths for CURRENT-PROJECT from PROJECTS and TARGET-DIRECTORIES.
 Returns a list of (alias . path) pairs."
-  (let ((alias-list (cdr (assoc current-project projects))))
-    (cl-loop for alias in alias-list
-             for project-info = (enkan-repl--get-project-info-from-directories
-                                 alias target-directories)
-             when project-info
-             collect (cons alias (cdr project-info)))))
+  (let ((alias-list (cdr (assoc current-project projects)))
+        paths)
+    (setq paths
+          (cl-loop for alias in alias-list
+                   for project-info = (enkan-repl--get-project-info-from-directories
+                                       alias target-directories)
+                   when project-info
+                   collect (cons alias (cdr project-info))))
+    (or paths
+        (cl-loop for entry in target-directories
+                 for alias = (car entry)
+                 for project-info = (cdr entry)
+                 when (and (consp project-info)
+                           (string= (car project-info) current-project))
+                 collect (cons alias (cdr project-info))))))
 
 (defun enkan-repl--resolve-send-target (pfx resolved-alias current-project projects target-directories)
   "Resolve target buffer from prefix/alias and project config.
@@ -1470,7 +1583,7 @@ Returns a plist with :status and other keys."
                                    collect (cons nil buffer)))))
       (if (null active-pairs)
           (list :status 'no-buffers
-                :message "No active enkan sessions found. Start one with M-x enkan-repl-start-eat")
+                :message "No active enkan sessions found. Start one with M-x enkan-repl-start-session")
         ;; Resolve based on prefix-arg or alias
         (cond
          ;; Priority 1: prefix-arg based selection
@@ -1698,6 +1811,10 @@ Returns plist with :buffer, :name, :live-p, :has-process, :process."
   (when (bufferp buffer)
     (let* ((name (buffer-name buffer))
            (live-p (buffer-live-p buffer))
+           (tmux-mirror-p (and live-p
+                               (fboundp 'enkan-repl--terminal-tmux-mirror-buffer-alive-p)
+                               (enkan-repl--terminal-tmux-mirror-buffer-alive-p
+                                buffer)))
            (process-info (when live-p
                            (with-current-buffer buffer
                              (list :bound (boundp 'eat--process)
@@ -1705,7 +1822,10 @@ Returns plist with :buffer, :name, :live-p, :has-process, :process."
       (list :buffer buffer
             :name name
             :live-p live-p
-            :has-process (and process-info (plist-get process-info :bound) (plist-get process-info :process))
+            :has-process (or tmux-mirror-p
+                             (and process-info
+                                  (plist-get process-info :bound)
+                                  (plist-get process-info :process)))
             :process (when process-info (plist-get process-info :process))))))
 
 (defun enkan-repl--get-available-buffers (buffer-list)
@@ -1900,7 +2020,7 @@ match prior visual behavior on the eat backend."
 
 ;;;###autoload
 (defun enkan-repl-send-escape (&optional pfx)
-  "Send ESC key to eat session buffer with optional PFX.
+  "Send ESC key to enkan session buffer with optional PFX.
 - If called from enkan buffer: Send ESC to current buffer
 - If called from center file without prefix: Select from available enkan buffers
 - With numeric prefix: Send to buffer at that index (1-based)

--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -98,8 +98,9 @@
 (declare-function enkan-repl--buffer-matches-directory "enkan-repl-utils" (buffer-name target-directory &optional instance))
 (declare-function enkan-repl--buffer-alive-as-terminal-p "enkan-repl-utils" (buffer))
 (declare-function enkan-repl--terminal-tmux-alive-p "enkan-repl-terminal" (id))
-(declare-function enkan-repl--terminal-tmux--mirror-make "enkan-repl-terminal" (id))
+(declare-function enkan-repl--terminal-tmux--mirror-make "enkan-repl-terminal" (id &optional defer-refresh))
 (declare-function enkan-repl--terminal-tmux-kill-workspace "enkan-repl-terminal" (workspace-id))
+(declare-function enkan-repl-tmux-refresh-workspace "enkan-repl-terminal" (&optional quiet))
 (defvar enkan-repl--tmux-mirror-id)
 (defvar enkan-repl-terminal-backend)
 (declare-function enkan-repl--session-entry-project "enkan-repl-utils" (entry-value))
@@ -115,6 +116,7 @@
 (declare-function enkan-repl--terminal-display "enkan-repl-terminal" (id))
 (declare-function enkan-repl--terminal-id-instance "enkan-repl-terminal" (id))
 (declare-function enkan-repl-state-save "enkan-repl-state" (&optional file))
+(declare-function enkan-repl-state-tmux-reconcile "enkan-repl-state" (&optional file))
 (declare-function enkan-repl--extract-project-name "enkan-repl-utils" (buffer-name-or-path))
 (declare-function enkan-repl--is-enkan-buffer-name "enkan-repl-utils" (name))
 (declare-function enkan-repl--path->buffer-name "enkan-repl-utils" (path))
@@ -431,6 +433,88 @@ Returns the loaded plist, or nil if no state was found."
       (when enkan-repl-project-aliases
         (enkan-repl--update-target-directories-for-workspace)))
     plist))
+
+(defun enkan-repl--tmux-reattach-already-current-p (loaded-workspaces current-id)
+  "Return non-nil when LOADED-WORKSPACES and CURRENT-ID match current state."
+  (and current-id
+       (string= current-id enkan-repl--current-workspace)
+       (equal loaded-workspaces enkan-repl--workspaces)))
+
+(defun enkan-repl--tmux-ensure-restored-workspaces (workspace-ids)
+  "Ensure tmux mirror buffers exist for WORKSPACE-IDS without force-refreshing.
+Returns the total number of mirror buffers ensured."
+  (let ((previous-workspace enkan-repl--current-workspace)
+        (total 0))
+    (unwind-protect
+        (dolist (workspace-id workspace-ids total)
+          (setq enkan-repl--current-workspace workspace-id)
+          (dolist (id (or (enkan-repl--terminal-list) nil))
+            (when (enkan-repl--terminal-tmux--mirror-make id t)
+              (setq total (1+ total)))))
+      (setq enkan-repl--current-workspace previous-workspace))))
+
+;;;###autoload
+(defun enkan-repl-tmux-reattach (&optional file)
+  "Reconnect Emacs state to live tmux sessions using persisted workspace state.
+FILE defaults to `enkan-repl-state-file'.  The command reconciles the saved
+workspace state with live tmux sessions, restores the matching workspaces,
+selects the saved current workspace when possible, and recreates tmux mirror
+buffers for the restored workspaces.
+
+This command is intentionally manual; enkan-repl does not reattach on load."
+  (interactive)
+  (unless (eq enkan-repl-terminal-backend 'tmux)
+    (user-error "Current terminal backend is not tmux: %S"
+                enkan-repl-terminal-backend))
+  (unless (fboundp 'enkan-repl-state-tmux-reconcile)
+    (user-error "Enkan-repl-state is not loaded"))
+  (let* ((result (enkan-repl-state-tmux-reconcile file))
+         (loaded-workspaces (plist-get result :loaded-workspaces))
+         (restored-ids (plist-get result :restored))
+         (saved-current (plist-get result :current))
+         (current-id (cond
+                      ((and saved-current
+                            (member saved-current restored-ids))
+                       saved-current)
+                      ((and enkan-repl--current-workspace
+                            (member enkan-repl--current-workspace restored-ids))
+                       enkan-repl--current-workspace)
+                      (t (car restored-ids)))))
+    (unless result
+      (user-error "No persisted enkan-repl state was loaded"))
+    (unless loaded-workspaces
+      (user-error "No persisted workspace matched a live tmux session"))
+    (if (enkan-repl--tmux-reattach-already-current-p
+         loaded-workspaces current-id)
+        (progn
+          (message "Already reattached to %d workspace(s); no refresh needed"
+                   (length loaded-workspaces))
+          result)
+      (setq enkan-repl--workspaces loaded-workspaces)
+      (setq enkan-repl--current-workspace current-id)
+      (enkan-repl--load-workspace-state current-id)
+      (let ((ensured (enkan-repl--tmux-ensure-restored-workspaces
+                      restored-ids)))
+        (setq enkan-repl--current-workspace current-id)
+        (enkan-repl--load-workspace-state current-id)
+        (when (fboundp 'enkan-repl-state-save)
+          (ignore-errors (enkan-repl-state-save file)))
+        (message
+         "Reattached %d workspace(s), ensured %d tmux mirror buffer(s)%s"
+         (length loaded-workspaces)
+         ensured
+         (let ((dropped (plist-get result :dropped))
+               (orphans (plist-get result :orphan-tmux)))
+           (concat
+            (if dropped
+                (format ", dropped state-only: %s"
+                        (mapconcat #'identity dropped ", "))
+              "")
+            (if orphans
+                (format ", ignored orphan tmux: %s"
+                        (mapconcat #'identity orphans ", "))
+              ""))))
+        result))))
 
 ;;;; Workspace Management Pure Functions
 

--- a/examples/keybinding.el
+++ b/examples/keybinding.el
@@ -73,6 +73,8 @@ Requires magit to be installed."
        ("C-M-s"   . enkan-repl-setup)
        ("C-M-t"   . enkan-repl-workspace-delete)
        ("C-M-w"   . enkan-repl-workspace-switch)
+       ("C-M-g" . enkan-repl-tmux-refresh-workspace)
+       ("C-M-r" . enkan-repl-tmux-reattach)
        ("C-M-l"   . enkan-repl-setup-current-project-layout))))
 
 ;; Refresh keymap after setting bindings

--- a/examples/window-layouts.el
+++ b/examples/window-layouts.el
@@ -33,8 +33,8 @@ PROJECT-REGISTRY format: ((alias . (project-name . project-path)) ...)"
          (project-path (when project-info (cdr (cdr project-info)))))
     project-path))
 
-(defun enkan-repl--setup-window-eat-buffer-pure (window session-number session-list project-registry)
-  "Pure function to determine eat buffer setup for WINDOW and SESSION-NUMBER.
+(defun enkan-repl--setup-window-terminal-buffer-pure (window session-number session-list project-registry)
+  "Pure function to determine terminal buffer setup for WINDOW and SESSION-NUMBER.
 Returns cons (window . buffer-name) or nil if session not registered.
 Honors the multi-instance index stored in SESSION-LIST so different
 instances of the same project map to distinct buffer names with <N>
@@ -46,7 +46,7 @@ suffix."
       (let ((project-path (enkan-repl--get-project-path-from-directories project-name project-registry)))
         (when project-path
           (let* ((expanded-path (expand-file-name project-path))
-                 ;; Ensure path ends with / for consistency with eat buffer names
+                 ;; Ensure path ends with / for consistency with terminal buffer names.
                  (normalized-path (if (string-suffix-p "/" expanded-path)
                                       expanded-path
                                     (concat expanded-path "/")))
@@ -61,6 +61,51 @@ suffix."
                                   (format "%s<%d>" base instance)
                                 base)))
             (cons window buffer-name)))))))
+
+(defun enkan-repl--registered-session-buffer-for-entry (entry)
+  "Return the live terminal buffer corresponding to session ENTRY.
+ENTRY is one element of `enkan-repl-session-list'.  Prefer the exact path
+registered through `enkan-repl-target-directories'.  When no project path is
+configured, fall back to matching the project name encoded in existing buffer
+names.  Stray buffers whose paths do not correspond to registered sessions are
+not returned."
+  (let* ((session-number (car entry))
+         (entry-value (cdr entry))
+         (project-name (enkan-repl--session-entry-project entry-value))
+         (instance (enkan-repl--session-entry-instance entry-value))
+         (setup (enkan-repl--setup-window-terminal-buffer-pure
+                 nil session-number (enkan-repl--ws-session-list)
+                 enkan-repl-target-directories))
+         (exact-buffer (and setup (get-buffer (cdr setup)))))
+    (cond
+     ((and exact-buffer
+           (enkan-repl--buffer-alive-as-terminal-p exact-buffer))
+      exact-buffer)
+     (project-name
+      (cl-find-if
+       (lambda (buffer)
+         (let ((name (buffer-name buffer)))
+           (and name
+                (enkan-repl--buffer-name-matches-workspace
+                 name enkan-repl--current-workspace)
+                (string= (or (enkan-repl--extract-project-name name) "")
+                         project-name)
+                (= (enkan-repl--buffer-name->instance name) instance)
+                (enkan-repl--buffer-alive-as-terminal-p buffer))))
+       (buffer-list))))))
+
+(defun enkan-repl--registered-session-buffers ()
+  "Return live terminal buffers registered for the current workspace.
+The returned list follows session slot order and excludes stray tmux mirror
+buffers that merely share the same workspace prefix.  Duplicate session-list
+entries that resolve to the same buffer are collapsed."
+  (let (buffers)
+    (dolist (entry (sort (copy-sequence (enkan-repl--ws-session-list))
+                         (lambda (a b) (< (car a) (car b)))))
+      (let ((buffer (enkan-repl--registered-session-buffer-for-entry entry)))
+        (when (and buffer (not (memq buffer buffers)))
+          (push buffer buffers))))
+    (nreverse buffers)))
 
 ;;;; Window Layout Variables
 
@@ -77,21 +122,29 @@ suffix."
 
 ;;;; Window Layout Functions
 
-;; Helper function for setting up eat buffer in window
-(defun enkan-repl--setup-session-eat-buffer (window session-number)
-  "Setup eat buffer for SESSION-NUMBER in WINDOW."
-  (let ((eat-setup (enkan-repl--setup-window-eat-buffer-pure
-                     window session-number (enkan-repl--ws-session-list) enkan-repl-target-directories)))
-    (if eat-setup
-      (let ((buffer (get-buffer (cdr eat-setup))))
+;;;###autoload
+(defun other-window-or-split ()
+  "Move to the next window, splitting the frame when only one window exists."
+  (interactive)
+  (when (one-window-p)
+    (split-window-right))
+  (other-window 1))
+
+;; Helper function for setting up terminal buffer in window.
+(defun enkan-repl--setup-session-terminal-buffer (window session-number)
+  "Setup terminal buffer for SESSION-NUMBER in WINDOW."
+  (let ((terminal-setup (enkan-repl--setup-window-terminal-buffer-pure
+                         window session-number (enkan-repl--ws-session-list) enkan-repl-target-directories)))
+    (if terminal-setup
+      (let ((buffer (get-buffer (cdr terminal-setup))))
         (if buffer
           (progn
-            (select-window (car eat-setup))
+            (select-window (car terminal-setup))
             (switch-to-buffer buffer)
-            (message "✅ Window %d: Opened eat buffer %s"
-                    session-number (cdr eat-setup)))
-          (message "❌ Window %d: Eat buffer %s not found. Run C-M-s to start sessions."
-            session-number (cdr eat-setup))))
+            (message "✅ Window %d: Opened terminal buffer %s"
+                    session-number (cdr terminal-setup)))
+          (message "❌ Window %d: Terminal buffer %s not found. Run C-M-s to start sessions."
+            session-number (cdr terminal-setup))))
       (message "❌ Window %d: No session registered for slot %d (internal number %d)."
         session-number session-number session-number))))
 
@@ -121,14 +174,14 @@ Category: Utilities"
     (select-window enkan-repl--window-1)
     (find-file enkan-repl-center-file)
     (message "✅ Window 1: Opened center file %s" enkan-repl-center-file))
-  ;; Setup eat buffers in session windows - use actual living buffers
-  (let ((available-buffers (enkan-repl--get-available-buffers (buffer-list))))
+  ;; Setup terminal buffers in session windows - use actual living buffers.
+  (let ((available-buffers (enkan-repl--registered-session-buffers)))
     (when (and available-buffers (> (length available-buffers) 0))
       ;; Use first available buffer in window 2
       (when enkan-repl--window-2
         (select-window enkan-repl--window-2)
         (switch-to-buffer (car available-buffers))
-        (message "✅ Window 2: Opened eat buffer %s" (buffer-name (car available-buffers))))))
+        (message "✅ Window 2: Opened terminal buffer %s" (buffer-name (car available-buffers))))))
   ;; Always select the center file window (Window 1) at the end
   (when enkan-repl--window-1
     (select-window enkan-repl--window-1)))
@@ -166,19 +219,19 @@ Category: Utilities"
     (select-window enkan-repl--window-1)
     (find-file enkan-repl-center-file)
     (message "✅ Window 1: Opened center file %s" enkan-repl-center-file))
-  ;; Setup eat buffers in session windows - use actual living buffers
-  (let ((available-buffers (enkan-repl--get-available-buffers (buffer-list))))
+  ;; Setup terminal buffers in session windows - use actual living buffers.
+  (let ((available-buffers (enkan-repl--registered-session-buffers)))
     (when (and available-buffers (> (length available-buffers) 0))
       ;; Place first buffer in window 2
       (when enkan-repl--window-2
         (select-window enkan-repl--window-2)
         (switch-to-buffer (car available-buffers))
-        (message "✅ Window 2: Opened eat buffer %s" (buffer-name (car available-buffers))))
+        (message "✅ Window 2: Opened terminal buffer %s" (buffer-name (car available-buffers))))
       ;; Place second buffer in window 3 if exists
       (when (and (> (length available-buffers) 1) enkan-repl--window-3)
         (select-window enkan-repl--window-3)
         (switch-to-buffer (cadr available-buffers))
-        (message "✅ Window 3: Opened eat buffer %s" (buffer-name (cadr available-buffers))))))
+        (message "✅ Window 3: Opened terminal buffer %s" (buffer-name (cadr available-buffers))))))
   ;; Always select the center file window (Window 1) at the end
   (when enkan-repl--window-1
     (select-window enkan-repl--window-1)))
@@ -219,24 +272,24 @@ Category: Utilities"
     (select-window enkan-repl--window-1)
     (find-file enkan-repl-center-file)
     (message "✅ Window 1: Opened center file %s" enkan-repl-center-file))
-  ;; Setup eat buffers in session windows - use actual living buffers
-  (let ((available-buffers (enkan-repl--get-available-buffers (buffer-list))))
+  ;; Setup terminal buffers in session windows - use actual living buffers.
+  (let ((available-buffers (enkan-repl--registered-session-buffers)))
     (when (and available-buffers (> (length available-buffers) 0))
       ;; Place first buffer in window 2
       (when enkan-repl--window-2
         (select-window enkan-repl--window-2)
         (switch-to-buffer (car available-buffers))
-        (message "✅ Window 2: Opened eat buffer %s" (buffer-name (car available-buffers))))
+        (message "✅ Window 2: Opened terminal buffer %s" (buffer-name (car available-buffers))))
       ;; Place second buffer in window 3 if exists
       (when (and (> (length available-buffers) 1) enkan-repl--window-3)
         (select-window enkan-repl--window-3)
         (switch-to-buffer (cadr available-buffers))
-        (message "✅ Window 3: Opened eat buffer %s" (buffer-name (cadr available-buffers))))
+        (message "✅ Window 3: Opened terminal buffer %s" (buffer-name (cadr available-buffers))))
       ;; Place third buffer in window 4 if exists
       (when (and (> (length available-buffers) 2) enkan-repl--window-4)
         (select-window enkan-repl--window-4)
         (switch-to-buffer (caddr available-buffers))
-        (message "✅ Window 4: Opened eat buffer %s" (buffer-name (caddr available-buffers))))))
+        (message "✅ Window 4: Opened terminal buffer %s" (buffer-name (caddr available-buffers))))))
   ;; Always select the center file window (Window 1) at the end
   (when enkan-repl--window-1
     (select-window enkan-repl--window-1)))
@@ -281,29 +334,29 @@ Category: Utilities"
     (select-window enkan-repl--window-1)
     (find-file enkan-repl-center-file)
     (message "✅ Window 1: Opened center file %s" enkan-repl-center-file))
-  ;; Setup eat buffers in session windows - use actual living buffers
-  (let ((available-buffers (enkan-repl--get-available-buffers (buffer-list))))
+  ;; Setup terminal buffers in session windows - use actual living buffers.
+  (let ((available-buffers (enkan-repl--registered-session-buffers)))
     (when (and available-buffers (> (length available-buffers) 0))
       ;; Place first buffer in window 2
       (when enkan-repl--window-2
         (select-window enkan-repl--window-2)
         (switch-to-buffer (car available-buffers))
-        (message "✅ Window 2: Opened eat buffer %s" (buffer-name (car available-buffers))))
+        (message "✅ Window 2: Opened terminal buffer %s" (buffer-name (car available-buffers))))
       ;; Place second buffer in window 3 if exists
       (when (and (> (length available-buffers) 1) enkan-repl--window-3)
         (select-window enkan-repl--window-3)
         (switch-to-buffer (cadr available-buffers))
-        (message "✅ Window 3: Opened eat buffer %s" (buffer-name (cadr available-buffers))))
+        (message "✅ Window 3: Opened terminal buffer %s" (buffer-name (cadr available-buffers))))
       ;; Place third buffer in window 4 if exists
       (when (and (> (length available-buffers) 2) enkan-repl--window-4)
         (select-window enkan-repl--window-4)
         (switch-to-buffer (caddr available-buffers))
-        (message "✅ Window 4: Opened eat buffer %s" (buffer-name (caddr available-buffers))))
+        (message "✅ Window 4: Opened terminal buffer %s" (buffer-name (caddr available-buffers))))
       ;; Place fourth buffer in window 5 if exists
       (when (and (> (length available-buffers) 3) enkan-repl--window-5)
         (select-window enkan-repl--window-5)
         (switch-to-buffer (cadddr available-buffers))
-        (message "✅ Window 5: Opened eat buffer %s" (buffer-name (cadddr available-buffers))))))
+        (message "✅ Window 5: Opened terminal buffer %s" (buffer-name (cadddr available-buffers))))))
   ;; Always select the center file window (Window 1) at the end
   (when enkan-repl--window-1
     (select-window enkan-repl--window-1)))
@@ -321,10 +374,11 @@ Category: Utilities"
     (error "No current project active. Run enkan-repl-setup first"))
   (unless enkan-repl--current-workspace
     (error "No current workspace active"))
-  ;; Count actual living buffers for current workspace
-  (let ((session-count (enkan-repl--get-workspace-buffer-count-pure 
-                        (buffer-list) 
-                        enkan-repl--current-workspace)))
+  ;; Count registered live buffers for current workspace.  Do not use every
+  ;; mirror buffer with the workspace prefix: stale tmux windows can recreate
+  ;; stray mirrors asynchronously, and those must not drive the layout.
+  (let* ((session-buffers (enkan-repl--registered-session-buffers))
+         (session-count (length session-buffers)))
     (message "Setting up layout for %d actual sessions in workspace '%s' for project '%s'..."
       session-count enkan-repl--current-workspace (enkan-repl--ws-current-project))
     (cond

--- a/test/debug-actual-buffer-names.el
+++ b/test/debug-actual-buffer-names.el
@@ -33,7 +33,7 @@
         (message "  Buffer name: %s" buffer-name)
         (message ""))))
   
-  ;; Test what enkan-repl--setup-window-eat-buffer-pure generates
+  ;; Test what enkan-repl--setup-window-terminal-buffer-pure generates
   (let ((enkan-repl--current-workspace "01")
         (session-list '((1 . "er")))
         (target-directories '(("er-alias" . ("er" . "/Users/sekine/dev/self/er"))))
@@ -41,11 +41,11 @@
         (target-directories3 '(("er-alias" . ("er" . "~/dev/self/er"))))
         (target-directories4 '(("er-alias" . ("er" . "~/dev/self/er/")))))
     
-    (message "\n=== Testing setup-window-eat-buffer-pure with different path formats ===")
+    (message "\n=== Testing setup-window-terminal-buffer-pure with different path formats ===")
     
-    (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
+    (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
       ;; Test without trailing slash
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'test-window 1 session-list target-directories)))
         (message "Target dir without trailing slash: %s" 
                  (cdr (assoc "er-alias" target-directories)))
@@ -53,7 +53,7 @@
         (message ""))
       
       ;; Test with trailing slash
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'test-window 1 session-list target-directories2)))
         (message "Target dir with trailing slash: %s" 
                  (cdr (assoc "er-alias" target-directories2)))
@@ -61,7 +61,7 @@
         (message ""))
       
       ;; Test with ~ notation
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'test-window 1 session-list target-directories3)))
         (message "Target dir with ~: %s" 
                  (cdr (assoc "er-alias" target-directories3)))
@@ -69,7 +69,7 @@
         (message ""))
       
       ;; Test with ~ and trailing slash
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'test-window 1 session-list target-directories4)))
         (message "Target dir with ~ and trailing slash: %s" 
                  (cdr (assoc "er-alias" target-directories4)))
@@ -85,7 +85,7 @@
     
     (unwind-protect
         (progn
-          ;; Create buffer as enkan-repl-start-eat would
+          ;; Create buffer as enkan-repl-start-session would
           (let ((buffer-name (enkan-repl--path->buffer-name default-directory)))
             (message "Creating buffer with name: %s" buffer-name)
             (setq buffer (generate-new-buffer buffer-name))
@@ -95,14 +95,14 @@
             (should (get-buffer buffer-name))
             (message "Buffer created successfully: %s" (buffer-name buffer))
             
-            ;; Now test if setup-window-eat-buffer-pure can find it
+            ;; Now test if setup-window-terminal-buffer-pure can find it
             (let* ((session-list '((1 . "er")))
                    (target-directories '(("er-alias" . ("er" . "/Users/sekine/dev/self/er"))))
-                   (result (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
-                            (enkan-repl--setup-window-eat-buffer-pure
+                   (result (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
+                            (enkan-repl--setup-window-terminal-buffer-pure
                              'test-window 1 session-list target-directories))))
               
-              (message "setup-window-eat-buffer-pure returned: %s" (cdr result))
+              (message "setup-window-terminal-buffer-pure returned: %s" (cdr result))
               
               ;; Check if the generated name matches
               (should result)

--- a/test/debug-workspace-issue.el
+++ b/test/debug-workspace-issue.el
@@ -89,13 +89,13 @@
       ;; This is the problem - target-directories might be empty
       (should enkan-repl-target-directories)
       
-      ;; Test setup-window-eat-buffer-pure
-      (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
-        (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      ;; Test setup-window-terminal-buffer-pure
+      (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
+        (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                        'test-window 1
                        enkan-repl-session-list
                        enkan-repl-target-directories)))
-          (message "setup-window-eat-buffer-pure result: %s" result)
+          (message "setup-window-terminal-buffer-pure result: %s" result)
           (should result)
           (when result
             (should (string-match-p "\\*ws:01 enkan:/path/to/er/\\*" (cdr result)))))))))

--- a/test/enkan-repl-constants-test.el
+++ b/test/enkan-repl-constants-test.el
@@ -40,7 +40,7 @@
   (let ((function-names (mapcar #'car enkan-repl-cheat-sheet-candidates)))
     (should (member "enkan-repl-cheat-sheet" function-names))
     (should (member "enkan-repl-send-region" function-names))
-    (should (member "enkan-repl-start-eat" function-names))))
+    (should (member "enkan-repl-start-session" function-names))))
 
 (ert-deftest test-constants-consistency ()
   "Test that constants are consistent with function count."

--- a/test/enkan-repl-core-test.el
+++ b/test/enkan-repl-core-test.el
@@ -71,6 +71,86 @@
     (enkan-repl--register-session 1 "project-c")
     (should (equal enkan-repl-session-list '((1 . "project-c") (2 . "project-b"))))))
 
+(ert-deftest test-enkan-repl-tmux-reattach-restores-state ()
+  "Manual tmux reattach restores reconciled workspace state."
+  (let ((enkan-repl-terminal-backend 'tmux)
+        (enkan-repl--workspaces nil)
+        (enkan-repl--current-workspace "01")
+        (enkan-repl--current-project nil)
+        (enkan-repl-session-list nil)
+        (enkan-repl--session-counter 0)
+        (enkan-repl-project-aliases nil)
+        ensured-workspaces)
+    (cl-letf (((symbol-function 'enkan-repl-state-tmux-reconcile)
+               (lambda (&optional _file)
+                 '(:loaded-workspaces
+                   (("01" :current-project "old"
+                          :session-list ((1 . "old"))
+                          :session-counter 1
+                          :project-aliases nil)
+                    ("02" :current-project "proj"
+                          :session-list ((1 . "proj"))
+                          :session-counter 1
+                          :project-aliases (("p" . "proj"))))
+                   :restored ("01" "02")
+                   :dropped nil
+                   :orphan-tmux nil
+                   :current "02")))
+              ((symbol-function 'enkan-repl--terminal-list)
+               (lambda ()
+                 (list (format "enkan-%s:window"
+                               enkan-repl--current-workspace))))
+              ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
+               (lambda (id &optional defer-refresh)
+                 (push (list enkan-repl--current-workspace id defer-refresh)
+                       ensured-workspaces)
+                 id))
+              ((symbol-function 'enkan-repl-state-save)
+               (lambda (&optional _file) t)))
+      (let ((result (enkan-repl-tmux-reattach)))
+        (should result)
+        (should (equal "02" enkan-repl--current-workspace))
+        (should (equal "proj" enkan-repl--current-project))
+        (should (equal '((1 . "proj")) enkan-repl-session-list))
+        (should (equal '(("02" "enkan-02:window" t)
+                         ("01" "enkan-01:window" t))
+                       ensured-workspaces))))))
+
+(ert-deftest test-enkan-repl-tmux-reattach-skips-already-current-state ()
+  "Manual tmux reattach does not force-refresh when state is already current."
+  (let* ((saved-workspaces
+          '(("01" :current-project "old"
+                   :session-list ((1 . "old"))
+                   :session-counter 1
+                   :project-aliases nil)
+            ("02" :current-project "proj"
+                   :session-list ((1 . "proj"))
+                   :session-counter 1
+                   :project-aliases nil)))
+         (enkan-repl-terminal-backend 'tmux)
+         (enkan-repl--workspaces saved-workspaces)
+         (enkan-repl--current-workspace "02"))
+    (cl-letf (((symbol-function 'enkan-repl-state-tmux-reconcile)
+               (lambda (&optional _file)
+                 (list :loaded-workspaces saved-workspaces
+                       :restored '("01" "02")
+                       :dropped nil
+                       :orphan-tmux nil
+                       :current "02")))
+              ((symbol-function 'enkan-repl--terminal-list)
+               (lambda ()
+                 (error "Should not list tmux windows when already current")))
+              ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
+               (lambda (_id &optional _defer-refresh)
+                 (error "Should not create mirrors when already current")))
+              ((symbol-function 'enkan-repl-state-save)
+               (lambda (&optional _file)
+                 (error "Should not save when already current"))))
+      (let ((result (enkan-repl-tmux-reattach)))
+        (should result)
+        (should (eq saved-workspaces enkan-repl--workspaces))
+        (should (string= "02" enkan-repl--current-workspace))))))
+
 ;; Tests for enkan-repl--get-package-directory
 (ert-deftest test-enkan-repl--get-package-directory ()
   "Test package directory detection."

--- a/test/enkan-repl-core-test.el
+++ b/test/enkan-repl-core-test.el
@@ -72,8 +72,17 @@
     (should (equal enkan-repl-session-list '((1 . "project-c") (2 . "project-b"))))))
 
 (ert-deftest test-enkan-repl-tmux-reattach-restores-state ()
-  "Manual tmux reattach restores reconciled workspace state."
-  (let ((enkan-repl-terminal-backend 'tmux)
+  "Manual tmux reattach restores persisted state for live tmux sessions."
+  (let ((saved-workspaces
+         '(("01" :current-project "old"
+                  :session-list ((1 . "old"))
+                  :session-counter 1
+                  :project-aliases nil)
+           ("02" :current-project "proj"
+                  :session-list ((1 . "proj"))
+                  :session-counter 1
+                  :project-aliases (("p" . "proj")))))
+        (enkan-repl-terminal-backend 'tmux)
         (enkan-repl--workspaces nil)
         (enkan-repl--current-workspace "01")
         (enkan-repl--current-project nil)
@@ -81,27 +90,21 @@
         (enkan-repl--session-counter 0)
         (enkan-repl-project-aliases nil)
         ensured-workspaces)
-    (cl-letf (((symbol-function 'enkan-repl-state-tmux-reconcile)
+    (cl-letf (((symbol-function 'enkan-repl-state-load)
                (lambda (&optional _file)
-                 '(:loaded-workspaces
-                   (("01" :current-project "old"
-                          :session-list ((1 . "old"))
-                          :session-counter 1
-                          :project-aliases nil)
-                    ("02" :current-project "proj"
-                          :session-list ((1 . "proj"))
-                          :session-counter 1
-                          :project-aliases (("p" . "proj"))))
-                   :restored ("01" "02")
-                   :dropped nil
-                   :orphan-tmux nil
-                   :current "02")))
+                 (list :workspaces saved-workspaces :current "02")))
+              ((symbol-function 'enkan-repl-state--list-live-tmux-sessions)
+               (lambda (_prefix)
+                 '("enkan-01" "enkan-02")))
+              ((symbol-function 'enkan-repl--terminal-tmux--list-windows)
+               (lambda (_session)
+                 '("window")))
               ((symbol-function 'enkan-repl--terminal-list)
                (lambda ()
                  (list (format "enkan-%s:window"
                                enkan-repl--current-workspace))))
               ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
-               (lambda (id &optional defer-refresh)
+               (lambda (id &optional defer-refresh _path)
                  (push (list enkan-repl--current-workspace id defer-refresh)
                        ensured-workspaces)
                  id))
@@ -114,6 +117,50 @@
         (should (equal '((1 . "proj")) enkan-repl-session-list))
         (should (equal '(("02" "enkan-02:window" t)
                          ("01" "enkan-01:window" t))
+                       ensured-workspaces))))))
+
+(ert-deftest test-enkan-repl-tmux-reattach-imports-live-session-without-state ()
+  "Manual tmux reattach imports live tmux sessions when no state exists."
+  (let ((enkan-repl-terminal-backend 'tmux)
+        (enkan-repl--workspaces nil)
+        (enkan-repl--current-workspace nil)
+        (enkan-repl--current-project nil)
+        (enkan-repl-session-list nil)
+        (enkan-repl--session-counter 0)
+        (enkan-repl-project-aliases nil)
+        ensured-workspaces)
+    (cl-letf (((symbol-function 'enkan-repl-state-load)
+               (lambda (&optional _file) nil))
+              ((symbol-function 'enkan-repl-state--list-live-tmux-sessions)
+               (lambda (_prefix)
+                 '("enkan-03")))
+              ((symbol-function 'enkan-repl--terminal-tmux--list-windows)
+               (lambda (_session)
+                 '("enkan-repl" "worker-2")))
+              ((symbol-function 'enkan-repl--terminal-list)
+               (lambda ()
+                 (list "enkan-03:enkan-repl" "enkan-03:worker-2")))
+              ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
+               (lambda (id &optional defer-refresh _path)
+                 (push (list enkan-repl--current-workspace id defer-refresh)
+                       ensured-workspaces)
+                 id))
+              ((symbol-function 'enkan-repl-state-save)
+               (lambda (&optional _file) t)))
+      (let ((result (enkan-repl-tmux-reattach)))
+        (should result)
+        (should (equal '("03") (plist-get result :imported)))
+        (should (equal "03" enkan-repl--current-workspace))
+        (should (equal "enkan-repl" enkan-repl--current-project))
+        (should (equal '((1 . "enkan-repl") (2 . ("worker" . 2)))
+                       enkan-repl-session-list))
+        (should (equal '((1 . "enkan-repl") (2 . ("worker" . 2)))
+                       (plist-get (cdr (assoc "03" enkan-repl--workspaces
+                                              #'string=))
+                                  :session-list)))
+        (should (= 2 enkan-repl--session-counter))
+        (should (equal '(("03" "enkan-03:worker-2" t)
+                         ("03" "enkan-03:enkan-repl" t))
                        ensured-workspaces))))))
 
 (ert-deftest test-enkan-repl-tmux-reattach-skips-already-current-state ()
@@ -132,16 +179,21 @@
          (enkan-repl--current-workspace "02"))
     (cl-letf (((symbol-function 'enkan-repl-state-tmux-reconcile)
                (lambda (&optional _file)
-                 (list :loaded-workspaces saved-workspaces
-                       :restored '("01" "02")
-                       :dropped nil
-                       :orphan-tmux nil
-                       :current "02")))
+                 (error "Should not use old persisted-only reconcile")))
+              ((symbol-function 'enkan-repl-state-load)
+               (lambda (&optional _file)
+                 (list :workspaces saved-workspaces :current "02")))
+              ((symbol-function 'enkan-repl-state--list-live-tmux-sessions)
+               (lambda (_prefix)
+                 '("enkan-01" "enkan-02")))
+              ((symbol-function 'enkan-repl--terminal-tmux--list-windows)
+               (lambda (_session)
+                 '("window")))
               ((symbol-function 'enkan-repl--terminal-list)
                (lambda ()
                  (error "Should not list tmux windows when already current")))
               ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
-               (lambda (_id &optional _defer-refresh)
+               (lambda (_id &optional _defer-refresh _path)
                  (error "Should not create mirrors when already current")))
               ((symbol-function 'enkan-repl-state-save)
                (lambda (&optional _file)

--- a/test/enkan-repl-eat-buffer-creation-test.el
+++ b/test/enkan-repl-eat-buffer-creation-test.el
@@ -47,7 +47,7 @@
       
       ;; Start eat in first workspace
       (let ((default-directory "/path/to/enkan-repl/"))
-        (enkan-repl-start-eat))
+        (enkan-repl-start-session))
       
       ;; Check first buffer name
       (should (= (length renamed-buffers) 1))
@@ -69,7 +69,7 @@
       
       ;; Start eat in second workspace
       (let ((default-directory "/path/to/enkan-repl/"))
-        (enkan-repl-start-eat))
+        (enkan-repl-start-session))
       
       ;; Check second buffer name - THE PROBLEM!
       (should (= (length renamed-buffers) 2))

--- a/test/enkan-repl-functions-test.el
+++ b/test/enkan-repl-functions-test.el
@@ -127,6 +127,17 @@
     (should (equal (plist-get result :status) 'single))
     (should (equal (plist-get result :path) "/path/to/proj1"))
     (should (equal (plist-get result :alias) "alias1")))
+
+  ;; Test with current project as an actual project name, not a project config.
+  (let ((result (enkan-repl--target-directory-info
+                 "Project One"
+                 nil
+                 '(("alias1" "Project One" . "/path/to/proj1"))
+                 "Select project:"
+                 nil)))
+    (should (equal (plist-get result :status) 'single))
+    (should (equal (plist-get result :path) "/path/to/proj1"))
+    (should (equal (plist-get result :alias) "alias1")))
   
   ;; Test with validation failure
   (let ((result (enkan-repl--target-directory-info 
@@ -137,6 +148,80 @@
                  (lambda (path) (string-prefix-p "/valid" path)))))
     (should (equal (plist-get result :status) 'invalid))
     (should (equal (plist-get result :path) "/invalid/path"))))
+
+(ert-deftest test-enkan-repl-open-project-directory-current-project-name ()
+  "Open project directory when current project is a target project name."
+  (let ((tmpdir (file-name-as-directory
+                 (make-temp-file "enkan-open-project-" t)))
+        opened)
+    (unwind-protect
+        (let ((enkan-repl--current-project "enkan-repl")
+              (enkan-repl-projects nil)
+              (enkan-repl-target-directories nil))
+          (setq enkan-repl-target-directories
+                `(("er" . ("enkan-repl" . ,tmpdir))))
+          (cl-letf (((symbol-function 'dired)
+                     (lambda (path)
+                       (setq opened path))))
+            (enkan-repl-open-project-directory)
+            (should (equal opened tmpdir))))
+      (delete-directory tmpdir t))))
+
+(ert-deftest test-enkan-repl-keybinding-example-commands-defined ()
+  "Every command bound in examples/keybinding.el should be defined."
+  (let* ((repo-root (file-name-as-directory
+                     (expand-file-name default-directory)))
+         (examples-dir (expand-file-name "examples" repo-root))
+         (load-path (cons examples-dir load-path))
+         (old-bindings enkan-repl-global-minor-bindings)
+         (old-center enkan-repl-center-file)
+         (old-mode enkan-repl-global-minor-mode)
+         (expected-commands
+          '(enkan-repl-send-escape
+            enkan-repl-toggle-global-mode
+            enkan-repl-magit
+            enkan-repl-send-enter
+            enkan-repl-send-line
+            enkan-repl-send-1
+            enkan-repl-send-2
+            enkan-repl-send-3
+            enkan-repl-send-4
+            enkan-repl-send-5
+            enkan-repl-send-region
+            enkan-repl-open-project-directory
+            other-window-or-split
+            enkan-repl-recenter-bottom
+            enkan-repl-open-center-file
+            enkan-repl-setup
+            enkan-repl-workspace-delete
+            enkan-repl-workspace-switch
+            enkan-repl-tmux-refresh-workspace
+            enkan-repl-tmux-reattach
+            enkan-repl-setup-current-project-layout)))
+    (unwind-protect
+        (progn
+          (setq enkan-repl-global-minor-bindings nil)
+          (enkan-repl-global-minor-mode -1)
+          (load (expand-file-name "window-layouts.el" examples-dir) nil t)
+          (load (expand-file-name "keybinding.el" examples-dir) nil t)
+          (should (eq (cdr (assoc "C-M-s" enkan-repl-global-minor-bindings))
+                      'enkan-repl-setup))
+          (dolist (command expected-commands)
+            (should (fboundp command)))
+          (dolist (binding enkan-repl-global-minor-bindings)
+            (should (fboundp (cdr binding)))
+            (should (eq (lookup-key enkan-repl-global-minor-mode-map
+                                    (kbd (car binding)))
+                        (cdr binding)))
+            (should (eq (lookup-key
+                         (cdr (assq 'enkan-repl-global-minor-mode
+                                    minor-mode-map-alist))
+                         (kbd (car binding)))
+                        (cdr binding)))))
+      (setq enkan-repl-center-file old-center)
+      (setq enkan-repl-global-minor-bindings old-bindings)
+      (enkan-repl--refresh-global-minor-map)
+      (enkan-repl-global-minor-mode (if old-mode 1 -1)))))
 
 ;; Tests for enkan-repl--select-project
 (ert-deftest test-enkan-repl--select-project ()

--- a/test/enkan-repl-start-session-test.el
+++ b/test/enkan-repl-start-session-test.el
@@ -1,7 +1,7 @@
-;;; enkan-repl-start-eat-session-test.el --- Test for session registration on eat start -*- lexical-binding: t -*-
+;;; enkan-repl-start-session-test.el --- Test for session registration on start -*- lexical-binding: t -*-
 
 ;;; Commentary:
-;; Test that enkan-repl-start-eat properly registers sessions
+;; Test that enkan-repl-start-session properly registers sessions
 
 ;;; Code:
 
@@ -24,8 +24,8 @@ workspace starts at instance 1."
                  (string-match-p "^\\*ws:[0-9]\\{2\\} enkan:" name))
         (kill-buffer buf)))))
 
-(ert-deftest test-start-eat-registers-session ()
-  "Test that enkan-repl-start-eat registers session and saves workspace."
+(ert-deftest test-start-session-registers-session ()
+  "Test that enkan-repl-start-session registers session and saves workspace."
   (enkan-repl-test--kill-stale-enkan-buffers)
   ;; Exercises the eat backend explicitly (mocks `eat').
   (let ((enkan-repl-terminal-backend 'eat)
@@ -52,8 +52,8 @@ workspace starts at instance 1."
               ((symbol-function 'require)
                (lambda (_) t)))
       
-      ;; Call enkan-repl-start-eat
-      (enkan-repl-start-eat)
+      ;; Call enkan-repl-start-session
+      (enkan-repl-start-session)
       
       ;; Session should be registered
       (should (equal '((1 . "er")) enkan-repl-session-list))
@@ -70,7 +70,7 @@ workspace starts at instance 1."
         (kill-buffer mock-eat-buffer)))))
 
 (ert-deftest test-multiple-eat-sessions-in-workspace ()
-  "Test that multiple eat sessions are properly registered."
+  "Test that multiple terminal sessions are properly registered."
   (enkan-repl-test--kill-stale-enkan-buffers)
   ;; Exercises the eat backend explicitly (mocks `eat').
   (let ((enkan-repl-terminal-backend 'eat)
@@ -97,12 +97,12 @@ workspace starts at instance 1."
               ((symbol-function 'require)
                (lambda (_) t)))
       
-      ;; Start first eat session (instance 1 -> legacy string form)
-      (enkan-repl-start-eat)
+      ;; Start first terminal session (instance 1 -> legacy string form)
+      (enkan-repl-start-session)
       (should (equal '((1 . "er")) enkan-repl-session-list))
 
-      ;; Start second eat session (instance 2 -> cons form)
-      (enkan-repl-start-eat)
+      ;; Start second terminal session (instance 2 -> cons form)
+      (enkan-repl-start-session)
       (should (equal '((1 . "er") (2 "er" . 2)) enkan-repl-session-list))
       (should (= 2 enkan-repl--session-counter))
 
@@ -115,5 +115,34 @@ workspace starts at instance 1."
         (when (buffer-live-p buf)
           (kill-buffer buf))))))
 
-(provide 'enkan-repl-start-eat-session-test)
-;;; enkan-repl-start-eat-session-test.el ends here
+(ert-deftest test-setup-start-sessions-binds-project-directory ()
+  "Test setup starts sessions from the configured project directory.
+This preserves the old `enkan-repl-setup' -> starter behavior: keybinding
+workflows resolve project aliases before calling the backend-neutral starter."
+  (let* ((project-dir (file-name-as-directory
+                       (make-temp-file "enkan-start-session-" t)))
+         (log-buffer (generate-new-buffer " *enkan-start-session-log*"))
+         (started nil)
+         (enkan-repl-target-directories
+          `(("er" . ("enkan-repl" . ,project-dir))))
+         (enkan-repl-session-list nil)
+         (enkan-repl--session-counter 0)
+         (enkan-repl--current-project "enkan-repl")
+         (enkan-repl--current-workspace "01")
+         (enkan-repl--workspaces '(("01" . nil))))
+    (unwind-protect
+        (cl-letf (((symbol-function 'enkan-repl-start-session)
+                   (lambda (&optional force)
+                     (push (cons force default-directory) started))))
+          (enkan-repl--setup-start-sessions '("er") log-buffer)
+          (should (= 1 (length started)))
+          (should (eq (caar started) t))
+          (should (file-equal-p (cdar started) project-dir))
+          (should-not (file-equal-p (cdar started)
+                                    (expand-file-name "~/"))))
+      (when (buffer-live-p log-buffer)
+        (kill-buffer log-buffer))
+      (delete-directory project-dir t))))
+
+(provide 'enkan-repl-start-session-test)
+;;; enkan-repl-start-session-test.el ends here

--- a/test/enkan-repl-state-test.el
+++ b/test/enkan-repl-state-test.el
@@ -133,5 +133,27 @@ load it back, ensuring data survives serialization."
   (let ((enkan-repl-state-recovery-policy 'ignore))
     (should (null (enkan-repl-state-tmux-reconcile "/no/such/file")))))
 
+(ert-deftest test-enkan-repl-state-tmux-reconcile-keeps-current ()
+  "Reconcile result includes the persisted current workspace."
+  (let ((tmp (make-temp-file "enkan-repl-state-current-" nil ".eld"))
+        (enkan-repl-state-recovery-policy 'reattach)
+        (enkan-repl-tmux-session-prefix "enkan-"))
+    (unwind-protect
+        (progn
+          (with-temp-file tmp
+            (prin1 '(:schema-version 1
+                     :saved-at "2026-05-09T00:00:00+0900"
+                     :current "02"
+                     :workspaces (("01" :session-list nil)
+                                  ("02" :session-list nil)))
+                   (current-buffer)))
+          (cl-letf (((symbol-function 'enkan-repl-state--list-live-tmux-sessions)
+                     (lambda (_prefix) '("enkan-02"))))
+            (let ((result (enkan-repl-state-tmux-reconcile tmp)))
+              (should (equal '("02") (plist-get result :restored)))
+              (should (string= "02" (plist-get result :current))))))
+      (when (file-exists-p tmp)
+        (delete-file tmp)))))
+
 (provide 'enkan-repl-state-test)
 ;;; enkan-repl-state-test.el ends here

--- a/test/enkan-repl-terminal-test.el
+++ b/test/enkan-repl-terminal-test.el
@@ -50,6 +50,16 @@ documented opt-in alternative; see README."
   (should (null (enkan-repl--terminal-tmux--id-window "no-colon")))
   (should (null (enkan-repl--terminal-tmux--id-window nil))))
 
+(ert-deftest test-enkan-repl--terminal-tmux--id-workspace ()
+  "Workspace id is parsed from tmux target session names."
+  (let ((enkan-repl-tmux-session-prefix "enkan-"))
+    (should (string= "02"
+                     (enkan-repl--terminal-tmux--id-workspace
+                      "enkan-02:lat")))
+    (should (null
+             (enkan-repl--terminal-tmux--id-workspace
+              "other-02:lat")))))
+
 (ert-deftest test-enkan-repl--terminal-tmux-id-instance ()
   "Instance index parsed from -N suffix in window name."
   (should (= 1 (enkan-repl--terminal-tmux-id-instance "enkan-01:lat")))
@@ -69,6 +79,25 @@ documented opt-in alternative; see README."
   (should (string= "root"
                    (enkan-repl--terminal-tmux--derive-base-name "/"))))
 
+;;;; bounded tmux control calls
+
+(ert-deftest test-enkan-repl--terminal-tmux--call-captures-output ()
+  "Synchronous tmux control wrapper should capture output."
+  (let ((enkan-repl-tmux-executable "sh")
+        (enkan-repl-tmux-command-timeout 1.0))
+    (should (string= "ok"
+                     (enkan-repl--terminal-tmux--call
+                      '("-c" "printf ok") t)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--call-times-out ()
+  "Synchronous tmux control wrapper should be bounded by timeout."
+  (let ((enkan-repl-tmux-executable "sh")
+        (enkan-repl-tmux-command-timeout 0.05)
+        (started (float-time)))
+    (should-not (enkan-repl--terminal-tmux--call
+                 '("-c" "sleep 1") nil))
+    (should (< (- (float-time) started) 0.5))))
+
 ;;;; tmux session name from current workspace
 
 (ert-deftest test-enkan-repl--terminal-tmux--workspace-session ()
@@ -82,6 +111,151 @@ documented opt-in alternative; see README."
                      (enkan-repl--terminal-tmux--workspace-session))))
   (let ((enkan-repl--current-workspace nil))
     (should (null (enkan-repl--terminal-tmux--workspace-session)))))
+
+;;;; tmux bell notification monitor
+
+(ert-deftest test-enkan-repl--terminal-tmux--bell-alert-targets ()
+  "Bell alert parsing should return only windows with the tmux bell flag."
+  (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--call)
+             (lambda (_args _capture)
+               "lat\t1\nother\t0\nwork\t1\n")))
+    (should (equal '("enkan-01:lat" "enkan-01:work")
+                   (enkan-repl--terminal-tmux--bell-alert-targets
+                    "enkan-01")))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--bell-monitor-notifies-once ()
+  "Bell monitor should notify only newly observed bell alert flags."
+  (let ((enkan-repl-tmux-bell-notify t)
+        (enkan-repl-tmux-bell-notify-interval 2.0)
+        (enkan-repl--tmux-bell-monitor-seen (make-hash-table :test #'equal))
+        notified)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--bell-monitor-sessions)
+               (lambda () '("enkan-01")))
+              ((symbol-function 'enkan-repl--terminal-tmux--bell-alert-targets)
+               (lambda (_session) '("enkan-01:lat")))
+              ((symbol-function 'enkan-repl--terminal-tmux--all-targets)
+               (lambda (_session) nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--bell-notify)
+               (lambda (target &optional _kind) (push target notified))))
+      (enkan-repl--terminal-tmux--bell-monitor-poll)
+      (enkan-repl--terminal-tmux--bell-monitor-poll)
+      (should (equal '("enkan-01:lat") notified)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--bell-monitor-resets-cleared-alerts ()
+  "Bell monitor should allow a later alert after tmux clears the flag."
+  (let ((enkan-repl-tmux-bell-notify t)
+        (enkan-repl-tmux-bell-notify-interval 2.0)
+        (enkan-repl--tmux-bell-monitor-seen (make-hash-table :test #'equal))
+        (targets '(("enkan-01:lat") nil ("enkan-01:lat")))
+        notified)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--bell-monitor-sessions)
+               (lambda () '("enkan-01")))
+              ((symbol-function 'enkan-repl--terminal-tmux--bell-alert-targets)
+               (lambda (_session) (pop targets)))
+              ((symbol-function 'enkan-repl--terminal-tmux--all-targets)
+               (lambda (_session) nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--bell-notify)
+               (lambda (target &optional _kind) (push target notified))))
+      (enkan-repl--terminal-tmux--bell-monitor-poll)
+      (enkan-repl--terminal-tmux--bell-monitor-poll)
+      (enkan-repl--terminal-tmux--bell-monitor-poll)
+      (should (equal '("enkan-01:lat" "enkan-01:lat") notified)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--prompt-content-p ()
+  "Permission prompt detection covers common Claude/Codex wording."
+  (should (enkan-repl--terminal-tmux--prompt-content-p
+           "Codex needs approval to run command. Allow command?"))
+  (should (enkan-repl--terminal-tmux--prompt-content-p
+           "Claude Code permission required\nApprove tool use?"))
+  (should-not (enkan-repl--terminal-tmux--prompt-content-p
+               "Build finished successfully.")))
+
+(ert-deftest test-enkan-repl--terminal-tmux--prompt-alert-targets ()
+  "Prompt alerts should be detected from bounded pane captures."
+  (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--all-targets)
+             (lambda (_session) '("enkan-01:lat" "enkan-01:codex")))
+            ((symbol-function 'enkan-repl--terminal-tmux--alert-capture)
+             (lambda (target)
+               (if (string-suffix-p "codex" target)
+                   "Allow command?\ny/n"
+                 "idle output"))))
+    (should (equal '("enkan-01:codex")
+                   (enkan-repl--terminal-tmux--prompt-alert-targets
+                    "enkan-01")))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--alert-notify-refreshes-target ()
+  "Alert notification should force-refresh the alerting target's mirror."
+  (let ((enkan-repl-tmux-mirror t)
+        (buf (generate-new-buffer "*tmux alert refresh*"))
+        refreshed
+        message)
+    (unwind-protect
+        (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
+                   (lambda (target &optional defer-refresh)
+                     (should (string= target "enkan-01:codex"))
+                     (should defer-refresh)
+                     buf))
+                  ((symbol-function 'enkan-repl--terminal-tmux--mirror-refresh)
+                   (lambda (buffer &optional force)
+                     (setq refreshed (list buffer force))))
+                  ((symbol-function 'enkan-repl-notify-task-complete)
+                   (lambda (msg) (setq message msg))))
+          (enkan-repl--terminal-tmux--bell-notify "enkan-01:codex" 'prompt)
+          (should (equal (list buf t) refreshed))
+          (should (string-match-p "permission requested" message)))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--activity-alert-p ()
+  "Activity notification should fire after changed content settles."
+  (let ((enkan-repl-tmux-activity-notify t)
+        (enkan-repl-tmux-activity-notify-idle-seconds 1.0)
+        (enkan-repl--tmux-bell-monitor-content-state
+         (make-hash-table :test #'equal))
+        (t0 (seconds-to-time 100)))
+    (should-not
+     (enkan-repl--terminal-tmux--activity-alert-p
+      "enkan-01:codex" "old" t0))
+    (should-not
+     (enkan-repl--terminal-tmux--activity-alert-p
+      "enkan-01:codex" "new answer" (seconds-to-time 101)))
+    (should-not
+     (enkan-repl--terminal-tmux--activity-alert-p
+      "enkan-01:codex" "new answer" (seconds-to-time 101.5)))
+    (should
+     (enkan-repl--terminal-tmux--activity-alert-p
+      "enkan-01:codex" "new answer" (seconds-to-time 102.1)))
+    (should-not
+     (enkan-repl--terminal-tmux--activity-alert-p
+      "enkan-01:codex" "new answer" (seconds-to-time 103)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--bell-monitor-notifies-on-settled-output ()
+  "Bell monitor should notify when bounded pane content changes and settles."
+  (let ((enkan-repl-tmux-bell-notify t)
+        (enkan-repl-tmux-bell-notify-interval 2.0)
+        (enkan-repl-tmux-activity-notify t)
+        (enkan-repl-tmux-activity-notify-idle-seconds 0)
+        (enkan-repl-tmux-prompt-notify nil)
+        (enkan-repl--tmux-bell-monitor-seen (make-hash-table :test #'equal))
+        (enkan-repl--tmux-bell-monitor-content-state
+         (make-hash-table :test #'equal))
+        (captures '("old" "final answer" "final answer"))
+        notified)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--bell-monitor-sessions)
+               (lambda () '("enkan-01")))
+              ((symbol-function 'enkan-repl--terminal-tmux--bell-alert-targets)
+               (lambda (_session) nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--all-targets)
+               (lambda (_session) '("enkan-01:codex")))
+              ((symbol-function 'enkan-repl--terminal-tmux--alert-capture)
+               (lambda (_target) (pop captures)))
+              ((symbol-function 'enkan-repl--terminal-tmux--bell-notify)
+               (lambda (target &optional kind)
+                 (push (list target kind) notified))))
+      (enkan-repl--terminal-tmux--bell-monitor-poll)
+      (enkan-repl--terminal-tmux--bell-monitor-poll)
+      (enkan-repl--terminal-tmux--bell-monitor-poll)
+      (should (equal '(("enkan-01:codex" activity)) notified)))))
 
 ;;;; next-instance-name with list-windows mocked
 
@@ -117,34 +291,140 @@ documented opt-in alternative; see README."
 ;;;; tmux mirror buffer naming
 
 (ert-deftest test-enkan-repl--terminal-tmux--mirror-buffer-name ()
-  ;; When pane-cwd succeeds: mirror buffer name uses the eat backend
-  ;; format `*ws:NN enkan:/path/*' (with trailing slash) so existing
-  ;; buffer-list-based layout / send-target lookup finds tmux mirror
-  ;; buffers transparently.
+  ;; PATH is supplied by callers that already know the startup directory, or
+  ;; by the asynchronous cwd lookup after the fallback buffer is created.
   (let ((enkan-repl--current-workspace "01"))
-    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--pane-cwd)
-               (lambda (_id) "/path/to/lat")))
-      (should (string= "*ws:01 enkan:/path/to/lat/*"
-                       (enkan-repl--terminal-tmux--mirror-buffer-name
-                        "enkan-01:lat"))))
-    ;; pane-cwd already with trailing slash: idempotent
-    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--pane-cwd)
-               (lambda (_id) "/path/to/lat/")))
-      (should (string= "*ws:01 enkan:/path/to/lat/*"
-                       (enkan-repl--terminal-tmux--mirror-buffer-name
-                        "enkan-01:lat"))))
-    ;; instance suffix is honored (lat-3 -> instance 3 -> *<3>)
-    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--pane-cwd)
-               (lambda (_id) "/path/to/lat")))
-      (should (string= "*ws:01 enkan:/path/to/lat/*<3>"
-                       (enkan-repl--terminal-tmux--mirror-buffer-name
-                        "enkan-01:lat-3")))))
-  ;; When pane-cwd cannot be determined, falls back to *tmux <id>* form.
-  (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--pane-cwd)
-             (lambda (_id) nil)))
-    (should (string= "*tmux enkan-01:lat*"
+    (should (string= "*ws:01 enkan:/path/to/lat/*"
                      (enkan-repl--terminal-tmux--mirror-buffer-name
-                      "enkan-01:lat")))))
+                      "enkan-01:lat" "/path/to/lat")))
+    (should (string= "*ws:01 enkan:/path/to/lat/*"
+                     (enkan-repl--terminal-tmux--mirror-buffer-name
+                      "enkan-01:lat" "/path/to/lat/")))
+    ;; instance suffix is honored (lat-3 -> instance 3 -> *<3>)
+    (should (string= "*ws:01 enkan:/path/to/lat/*<3>"
+                     (enkan-repl--terminal-tmux--mirror-buffer-name
+                      "enkan-01:lat-3" "/path/to/lat"))))
+  ;; Without PATH, this function never calls tmux and immediately falls back.
+  (should (string= "*tmux enkan-01:lat*"
+                   (enkan-repl--terminal-tmux--mirror-buffer-name
+                    "enkan-01:lat"))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-buffer-name-uses-target-workspace ()
+  "Background tmux mirrors must use the workspace encoded in target ids."
+  (let ((enkan-repl--current-workspace "01")
+        (enkan-repl-tmux-session-prefix "enkan-"))
+    (should (string= "*ws:02 enkan:/path/to/lat/*"
+                     (enkan-repl--terminal-tmux--mirror-buffer-name
+                      "enkan-02:lat" "/path/to/lat")))))
+
+(ert-deftest test-enkan-repl-tmux-repair-mirror-buffer-names ()
+  "Existing tmux mirrors with wrong workspace prefixes should be repairable."
+  (let ((enkan-repl--current-workspace "01")
+        (enkan-repl-tmux-session-prefix "enkan-")
+        (buf (generate-new-buffer "*ws:01 enkan:/path/to/lat/*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (setq-local enkan-repl--tmux-mirror-id "enkan-02:lat"))
+          (cl-letf (((symbol-function 'message) (lambda (&rest _) nil)))
+            (should (= 1 (enkan-repl-tmux-repair-mirror-buffer-names))))
+          (should (string= "*ws:02 enkan:/path/to/lat/*"
+                           (buffer-name buf))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-make-does-not-block-on-cwd ()
+  "Mirror creation should not synchronously query pane cwd."
+  (let ((enkan-repl--current-workspace "01")
+        (buf nil)
+        cwd-lookup-started)
+    (unwind-protect
+          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--pane-cwd-async)
+                   (lambda (_id _callback)
+                     (setq cwd-lookup-started t)
+                     nil)))
+          (setq buf (enkan-repl--terminal-tmux--mirror-make
+                     "enkan-01:lat" t))
+          (should (buffer-live-p buf))
+          (should (string= "*tmux enkan-01:lat*" (buffer-name buf)))
+          (should cwd-lookup-started))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-make-renames-from-async-cwd ()
+  "Async cwd lookup renames fallback mirrors to path-based names."
+  (let ((enkan-repl--current-workspace "01")
+        (buf nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--pane-cwd-async)
+                   (lambda (_id callback)
+                     (funcall callback "/path/to/lat")
+                     nil)))
+          (setq buf (enkan-repl--terminal-tmux--mirror-make
+                     "enkan-01:lat" t))
+          (should (string= "*ws:01 enkan:/path/to/lat/*"
+                           (buffer-name buf))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-make-default-is-manual ()
+  "Mirror creation should not start timers or capture by default."
+  (let ((enkan-repl--current-workspace "01")
+        (enkan-repl-tmux-mirror-auto-refresh nil)
+        (buf nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--pane-cwd-async)
+                   (lambda (&rest _) nil))
+                  ((symbol-function 'enkan-repl--terminal-tmux--mirror-refresh)
+                   (lambda (&rest _)
+                     (error "must not auto-refresh"))))
+          (setq buf (enkan-repl--terminal-tmux--mirror-make
+                     "enkan-01:lat" nil))
+          (with-current-buffer buf
+            (should-not enkan-repl--tmux-mirror-timer)))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-make-auto-refresh-opt-in ()
+  "Mirror auto-refresh is available only when explicitly enabled."
+  (let ((enkan-repl--current-workspace "01")
+        (enkan-repl-tmux-mirror-auto-refresh t)
+        (enkan-repl-tmux-mirror-interval 10)
+        (buf nil)
+        refresh-count)
+    (unwind-protect
+        (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--pane-cwd-async)
+                   (lambda (&rest _) nil))
+                  ((symbol-function 'enkan-repl--terminal-tmux--mirror-refresh)
+                   (lambda (&rest _)
+                     (setq refresh-count (1+ (or refresh-count 0))))))
+          (setq buf (enkan-repl--terminal-tmux--mirror-make
+                     "enkan-01:lat" nil))
+          (with-current-buffer buf
+            (should enkan-repl--tmux-mirror-timer))
+          (should (= refresh-count 1)))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux-display-does-not-refresh ()
+  "Displaying a mirror should not capture pane content implicitly."
+  (let ((enkan-repl-tmux-mirror t)
+        (buf (generate-new-buffer "*tmux display manual*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
+                   (lambda (_id &rest _)
+                     buf))
+                  ((symbol-function 'enkan-repl--terminal-tmux--mirror-refresh)
+                   (lambda (&rest _)
+                     (error "must not refresh on display")))
+                  ((symbol-function 'pop-to-buffer-same-window)
+                   (lambda (buffer)
+                     (should (eq buffer buf))))
+                  ((symbol-function 'message)
+                   (lambda (&rest _) nil)))
+          (should (eq buf (enkan-repl--terminal-tmux-display "enkan-01:lat"))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
 
 (ert-deftest test-enkan-repl-tmux-refresh-workspace ()
   "Refresh command creates or updates mirrors for current tmux windows."
@@ -177,6 +457,72 @@ documented opt-in alternative; see README."
   "Move point to LINE in the current buffer."
   (goto-char (point-min))
   (forward-line (1- line)))
+
+(ert-deftest test-enkan-repl--terminal-tmux--tail-append-caps-content ()
+  "Tmux capture accumulation should keep only the bounded tail."
+  (should (string= "bcdef"
+                   (enkan-repl--terminal-tmux--tail-append
+                    "abc" "def" 5)))
+  (should (string= "cdefg"
+                   (enkan-repl--terminal-tmux--tail-append
+                    "ab" "cdefg" 5)))
+  (should (string= "abcdef"
+                   (enkan-repl--terminal-tmux--tail-append
+                    "abc" "def" nil))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-tail-lines ()
+  "Prepared tmux mirror content should keep only recent display lines."
+  (let ((enkan-repl-tmux-mirror-display-lines 3)
+        (enkan-repl-tmux-mirror-max-chars nil)
+        (enkan-repl-tmux-mirror-compact-noisy-blocks nil))
+    (should (string= "line 03\nline 04\nline 05"
+                     (enkan-repl--terminal-tmux--prepare-mirror-content
+                      (test-enkan-repl-terminal--lines 1 5))))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-compacts-diff ()
+  "Prepared tmux mirror content should collapse large diff-like blocks."
+  (let ((enkan-repl-tmux-mirror-display-lines 20)
+        (enkan-repl-tmux-mirror-max-chars nil)
+        (enkan-repl-tmux-mirror-compact-noisy-blocks t)
+        (enkan-repl-tmux-mirror-noisy-block-threshold 3))
+    (should (string= "message before\n[enkan-repl: omitted 4 noisy/diff line(s)]\nmessage after"
+                     (enkan-repl--terminal-tmux--prepare-mirror-content
+                      (string-join
+                       '("message before"
+                         "+added line"
+                         "-removed line"
+                         "@@ hunk"
+                         "diff --git a/file b/file"
+                         "message after")
+                       "\n"))))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-short-noisy-order ()
+  "Short noisy blocks should stay readable and preserve line order."
+  (let ((enkan-repl-tmux-mirror-display-lines 20)
+        (enkan-repl-tmux-mirror-max-chars nil)
+        (enkan-repl-tmux-mirror-compact-noisy-blocks t)
+        (enkan-repl-tmux-mirror-noisy-block-threshold 3))
+    (should (string= "message before\n+added\n-removed\nmessage after"
+                     (enkan-repl--terminal-tmux--prepare-mirror-content
+                      (string-join
+                       '("message before" "+added" "-removed" "message after")
+                       "\n"))))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-compacts-long-lines ()
+  "Repeated very long lines should be treated as noisy output."
+  (let ((enkan-repl-tmux-mirror-display-lines 20)
+        (enkan-repl-tmux-mirror-max-chars nil)
+        (enkan-repl-tmux-mirror-compact-noisy-blocks t)
+        (enkan-repl-tmux-mirror-noisy-block-threshold 2)
+        (enkan-repl-tmux-mirror-max-line-length 8))
+    (should (string= "before\n[enkan-repl: omitted 2 noisy/diff line(s)]\nafter"
+                     (enkan-repl--terminal-tmux--prepare-mirror-content
+                      (string-join
+                       (list "before"
+                             "0123456789abcdef"
+                             "abcdefghijklmnop"
+                             "after")
+                       "\n"))))))
 
 (ert-deftest test-enkan-repl--terminal-tmux--mirror-refresh-sticks-to-bottom ()
   "A tmux mirror window at the bottom should remain at the bottom after refresh."
@@ -211,7 +557,8 @@ documented opt-in alternative; see README."
   "A tmux mirror window away from the bottom should keep its scroll position."
   (let ((buf (generate-new-buffer "*tmux mirror scrolled*"))
         (initial-content (concat (test-enkan-repl-terminal--lines 1 200) "\n"))
-        (updated-content (concat (test-enkan-repl-terminal--lines 1 201) "\n")))
+        (updated-content (concat (test-enkan-repl-terminal--lines 1 201) "\n"))
+        (enkan-repl-tmux-mirror-display-lines 300))
     (unwind-protect
         (save-window-excursion
           (delete-other-windows)
@@ -330,6 +677,61 @@ documented opt-in alternative; see README."
             (should (eq enkan-repl--tmux-mirror-state 'fresh))))
       (kill-buffer buf))))
 
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-apply-avoids-buffer-diff ()
+  "Mirror application should not diff against a stale large buffer."
+  (let ((buf (generate-new-buffer "*tmux mirror replace*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq-local enkan-repl--tmux-mirror-id "enkan-01:p")
+          (insert (make-string 10000 ?x))
+          (let ((enkan-repl-tmux-mirror-display-lines 80)
+                (enkan-repl-tmux-mirror-max-chars (* 64 1024))
+                (enkan-repl-tmux-mirror-compact-noisy-blocks t))
+            (cl-letf (((symbol-function 'replace-buffer-contents)
+                       (lambda (&rest _)
+                         (error "must not diff mirror content"))))
+              (enkan-repl--terminal-tmux--mirror-apply-content
+               buf "enkan-01:p" (current-time) "fresh content" 0)))
+          (should (string= "fresh content"
+                           (buffer-substring-no-properties
+                            (point-min) (point-max)))))
+      (kill-buffer buf))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-timeout-keeps-buffer-open ()
+  "A timed-out tmux capture should not mark the pane as closed."
+  (let ((buf (generate-new-buffer "*tmux mirror timeout*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq-local enkan-repl--tmux-mirror-id "enkan-01:p")
+          (setq-local enkan-repl--tmux-mirror-refresh-process 'mock-process)
+          (insert "previous content")
+          (enkan-repl--terminal-tmux--mirror-apply-content
+           buf "enkan-01:p" (current-time) nil 'timeout)
+          (should (eq enkan-repl--tmux-mirror-state 'timed-out))
+          (should-not enkan-repl--tmux-mirror-refresh-process)
+          (should (string= "previous content"
+                           (buffer-substring-no-properties
+                            (point-min) (point-max)))))
+      (kill-buffer buf))))
+
+(ert-deftest test-enkan-repl-tmux-stop-all-mirrors ()
+  "Stop command cancels Emacs-side mirror timers without tmux calls."
+  (let ((buf (generate-new-buffer "*tmux mirror stop*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq-local enkan-repl--tmux-mirror-id "enkan-01:p")
+          (setq-local enkan-repl--tmux-mirror-timer
+                      (run-with-timer 1000 nil #'ignore))
+          (cl-letf (((symbol-function 'message) (lambda (&rest _) nil))
+                    ((symbol-function 'enkan-repl--terminal-tmux--call)
+                     (lambda (&rest _)
+                       (error "must not call tmux"))))
+            (should (= 1 (enkan-repl-tmux-stop-all-mirrors)))
+            (should-not enkan-repl--tmux-mirror-timer)
+            (should (eq enkan-repl--tmux-mirror-state 'stopped))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
 ;;;; attach helper default command (per-system shape)
 
 (ert-deftest test-enkan-repl--tmux-attach--default-command ()
@@ -373,6 +775,31 @@ must be coerced to that string id."
   (let ((enkan-repl-terminal-backend 'tmux))
     (should (string= "enkan-01:lat"
                      (enkan-repl--terminal--coerce-id "enkan-01:lat")))))
+
+(ert-deftest test-enkan-repl--terminal-alive-p-tmux-buffer-is-local ()
+  "Tmux mirror buffer liveness must not synchronously query tmux."
+  (let ((enkan-repl-terminal-backend 'tmux)
+        (buf (generate-new-buffer "*ws:01 enkan:/p/*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (setq-local enkan-repl--tmux-mirror-id "enkan-01:p"))
+          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux-alive-p)
+                     (lambda (_id)
+                       (error "must not synchronously query tmux"))))
+            (should (enkan-repl--terminal-alive-p buf))))
+      (kill-buffer buf))))
+
+(ert-deftest test-enkan-repl--terminal-alive-p-tmux-closed-buffer ()
+  "Closed tmux mirrors are not considered alive by the local check."
+  (let ((enkan-repl-terminal-backend 'tmux)
+        (buf (generate-new-buffer "*ws:01 enkan:/p/*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq-local enkan-repl--tmux-mirror-id "enkan-01:p")
+          (setq-local enkan-repl--tmux-mirror-state 'closed)
+          (should-not (enkan-repl--terminal-alive-p buf)))
+      (kill-buffer buf))))
 
 (ert-deftest test-enkan-repl--terminal--coerce-id-eat ()
   "Under eat backend, no coercion is applied."

--- a/test/enkan-repl-terminal-test.el
+++ b/test/enkan-repl-terminal-test.el
@@ -146,6 +146,25 @@ documented opt-in alternative; see README."
                      (enkan-repl--terminal-tmux--mirror-buffer-name
                       "enkan-01:lat")))))
 
+(ert-deftest test-enkan-repl-tmux-refresh-workspace ()
+  "Refresh command creates or updates mirrors for current tmux windows."
+  (let ((enkan-repl-terminal-backend 'tmux)
+        (enkan-repl-tmux-mirror t)
+        (enkan-repl--current-workspace "01")
+        refreshed)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux-list)
+               (lambda () '("enkan-01:a" "enkan-01:b")))
+              ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
+               (lambda (id &optional defer-refresh)
+                 (should defer-refresh)
+                 id))
+              ((symbol-function 'enkan-repl--terminal-tmux--mirror-refresh)
+               (lambda (buffer &optional force)
+                 (push (list buffer force) refreshed))))
+      (should (= 2 (enkan-repl-tmux-refresh-workspace t)))
+      (should (equal '(("enkan-01:b" t) ("enkan-01:a" t))
+                     refreshed)))))
+
 ;;;; tmux mirror buffer refresh scrolling
 
 (defun test-enkan-repl-terminal--lines (from to)
@@ -177,10 +196,10 @@ documented opt-in alternative; see README."
           (goto-char (point-max))
           (recenter -1)
           (redisplay t)
-          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux-alive-p)
-                     (lambda (_id) t))
-                    ((symbol-function 'enkan-repl--terminal-tmux--capture-pane)
-                     (lambda (_id _lines) updated-content)))
+          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--capture-pane-async)
+                     (lambda (id _lines callback)
+                       (funcall callback updated-content 0)
+                       nil)))
             (enkan-repl--terminal-tmux--mirror-refresh buf))
           (redisplay t)
           (should (= (window-point) (point-max)))
@@ -208,27 +227,25 @@ documented opt-in alternative; see README."
           (test-enkan-repl-terminal--goto-line 35)
           (set-window-point nil (point))
           (redisplay t)
-          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux-alive-p)
-                     (lambda (_id) t))
-                    ((symbol-function 'enkan-repl--terminal-tmux--capture-pane)
-                     (lambda (_id _lines) updated-content)))
+          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--capture-pane-async)
+                     (lambda (id _lines callback)
+                       (funcall callback updated-content 0)
+                       nil)))
             (enkan-repl--terminal-tmux--mirror-refresh buf))
           (should (= 30 (line-number-at-pos (window-start) t)))
           (should (= 35 (line-number-at-pos (window-point) t))))
       (kill-buffer buf))))
 
 (ert-deftest test-enkan-repl--terminal-tmux--mirror-refresh-skips-hidden ()
-  "A hidden tmux mirror should not run synchronous tmux capture."
+  "A hidden tmux mirror should not start tmux capture."
   (let ((buf (generate-new-buffer "*tmux mirror hidden*"))
         (capture-count 0))
     (unwind-protect
         (progn
           (with-current-buffer buf
             (setq-local enkan-repl--tmux-mirror-id "enkan-01:p"))
-          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux-alive-p)
-                     (lambda (_id) t))
-                    ((symbol-function 'enkan-repl--terminal-tmux--capture-pane)
-                     (lambda (_id _lines)
+          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--capture-pane-async)
+                     (lambda (_id _lines _callback)
                        (setq capture-count (1+ capture-count))
                        "hidden content")))
             (enkan-repl--terminal-tmux--mirror-refresh buf)
@@ -237,22 +254,59 @@ documented opt-in alternative; see README."
             (should (eq enkan-repl--tmux-mirror-state 'hidden)))))
       (kill-buffer buf))))
 
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-refresh-skips-minibuffer ()
+  "Timer refresh should not run while minibuffer completion is active."
+  (let ((buf (generate-new-buffer "*tmux mirror minibuffer*"))
+        (capture-called nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (setq-local enkan-repl--tmux-mirror-id "enkan-01:p"))
+          (cl-letf (((symbol-function 'active-minibuffer-window)
+                     (lambda () 'mock-minibuffer-window))
+                    ((symbol-function 'enkan-repl--terminal-tmux--capture-pane-async)
+                     (lambda (&rest _args)
+                       (setq capture-called t)
+                       "")))
+            (should (eq 'deferred
+                        (enkan-repl--terminal-tmux--mirror-refresh buf)))
+            (should-not capture-called)))
+      (kill-buffer buf))))
+
 (ert-deftest test-enkan-repl--terminal-tmux--mirror-refresh-shows-refreshing ()
-  "A tmux mirror should enter `refreshing' before synchronous capture starts."
+  "A tmux mirror should enter `refreshing' before capture completes."
   (let ((buf (generate-new-buffer "*tmux mirror status*"))
         observed-state)
     (unwind-protect
         (with-current-buffer buf
           (setq-local enkan-repl--tmux-mirror-id "enkan-01:p")
-          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux-alive-p)
-                     (lambda (_id) t))
-                    ((symbol-function 'enkan-repl--terminal-tmux--capture-pane)
-                     (lambda (_id _lines)
+          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--capture-pane-async)
+                     (lambda (_id _lines callback)
                        (setq observed-state enkan-repl--tmux-mirror-state)
-                       "status content")))
+                       (funcall callback "status content" 0)
+                       nil)))
             (enkan-repl--terminal-tmux--mirror-refresh buf t)
             (should (eq observed-state 'refreshing))
             (should (eq enkan-repl--tmux-mirror-state 'fresh))))
+      (kill-buffer buf))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--mirror-refresh-starts-async ()
+  "Refresh should return after starting capture without waiting for content."
+  (let ((buf (generate-new-buffer "*tmux mirror async*"))
+        callback-started)
+    (unwind-protect
+        (with-current-buffer buf
+          (setq-local enkan-repl--tmux-mirror-id "enkan-01:p")
+          (cl-letf (((symbol-function
+                      'enkan-repl--terminal-tmux--capture-pane-async)
+                     (lambda (_id _lines callback)
+                       (setq callback-started callback)
+                       nil)))
+            (should (eq 'refreshing
+                        (enkan-repl--terminal-tmux--mirror-refresh buf t)))
+            (should callback-started)
+            (should (eq enkan-repl--tmux-mirror-state 'refreshing))
+            (should (= (point-min) (point-max)))))
       (kill-buffer buf))))
 
 (ert-deftest test-enkan-repl--terminal-tmux-refresh-current-forces-hidden ()
@@ -262,12 +316,11 @@ documented opt-in alternative; see README."
     (unwind-protect
         (with-current-buffer buf
           (setq-local enkan-repl--tmux-mirror-id "enkan-01:p")
-          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux-alive-p)
-                     (lambda (_id) t))
-                    ((symbol-function 'enkan-repl--terminal-tmux--capture-pane)
-                     (lambda (_id _lines)
+          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--capture-pane-async)
+                     (lambda (_id _lines callback)
                        (setq capture-count (1+ capture-count))
-                       "manual content"))
+                       (funcall callback "manual content" 0)
+                       nil))
                     ((symbol-function 'message) (lambda (&rest _) nil)))
             (enkan-repl-tmux-refresh-current)
             (should (= 1 capture-count))

--- a/test/enkan-repl-workspace-actual-issue-test.el
+++ b/test/enkan-repl-workspace-actual-issue-test.el
@@ -74,10 +74,10 @@
                                    buffer))
                        buffer-selection-log))))
       
-      ;; Call enkan-repl--setup-session-eat-buffer 
+      ;; Call enkan-repl--setup-session-terminal-buffer
       ;; This is what enkan-repl-setup-1session-layout calls
-      (when (fboundp 'enkan-repl--setup-session-eat-buffer)
-        (enkan-repl--setup-session-eat-buffer 'dummy-window 1))
+      (when (fboundp 'enkan-repl--setup-session-terminal-buffer)
+        (enkan-repl--setup-session-terminal-buffer 'dummy-window 1))
       
       ;; Check log - should NOT open center file in eat window
       ;; But if eat buffer doesn't exist, it might fall back to center file
@@ -85,8 +85,8 @@
                                 (string-match-p "center\\.md" log))
                               buffer-selection-log)))))
 
-(ert-deftest test-setup-session-eat-buffer-logic ()
-  "Test the logic of enkan-repl--setup-session-eat-buffer."
+(ert-deftest test-setup-session-terminal-buffer-logic ()
+  "Test the logic of enkan-repl--setup-session-terminal-buffer."
   
   (let ((enkan-repl--current-workspace "01")
         (enkan-repl--session-list '((1 . "er")))
@@ -94,9 +94,9 @@
          '(("er-alias" . ("er" . "/path/to/er"))))
         test-buffer-name)
     
-    ;; Test: setup-window-eat-buffer-pure should return correct buffer name
-    (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+    ;; Test: setup-window-terminal-buffer-pure should return correct buffer name
+    (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'dummy-window 1 
                      enkan-repl--session-list
                      enkan-repl-target-directories)))
@@ -121,7 +121,7 @@
                  (error "switch-to-buffer should not be called when buffer doesn't exist"))))
       
       ;; When buffer doesn't exist, it should message an error, not switch
-      (when (fboundp 'enkan-repl--setup-session-eat-buffer)
+      (when (fboundp 'enkan-repl--setup-session-terminal-buffer)
         ;; Mock message to prevent actual output
         (cl-letf (((symbol-function 'message)
                    (lambda (&rest args)
@@ -130,7 +130,7 @@
                        t))))
           
           ;; This should not error - it should just show a message
-          (enkan-repl--setup-session-eat-buffer 'dummy-window 1))))))
+          (enkan-repl--setup-session-terminal-buffer 'dummy-window 1))))))
 
 (provide 'enkan-repl-workspace-actual-issue-test)
 ;;; enkan-repl-workspace-actual-issue-test.el ends here

--- a/test/enkan-repl-workspace-buffer-count-test.el
+++ b/test/enkan-repl-workspace-buffer-count-test.el
@@ -10,6 +10,7 @@
 ;; Load required files
 (load (expand-file-name "enkan-repl.el" default-directory) nil t)
 (load (expand-file-name "enkan-repl-utils.el" default-directory) nil t)
+(load (expand-file-name "enkan-repl-terminal.el" default-directory) nil t)
 
 (ert-deftest test-enkan-repl--get-workspace-buffer-count-pure ()
   "Test pure function to get living buffer count for workspace."
@@ -42,6 +43,27 @@
           (with-current-buffer buffer
             (when (and (boundp 'eat--process) eat--process)
               (delete-process eat--process)))
+          (kill-buffer buffer))))))
+
+(ert-deftest test-enkan-repl--get-workspace-buffer-count-tmux-local ()
+  "Counting tmux mirror buffers must not synchronously query tmux."
+  (let ((buffer1 (generate-new-buffer "*ws:01 enkan:/path/to/er/*"))
+        (buffer2 (generate-new-buffer "*ws:01 enkan:/path/to/dead/*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer1
+            (setq-local enkan-repl--tmux-mirror-id "enkan-01:er"))
+          (with-current-buffer buffer2
+            (setq-local enkan-repl--tmux-mirror-id "enkan-01:dead")
+            (setq-local enkan-repl--tmux-mirror-state 'closed))
+          (cl-letf (((symbol-function 'enkan-repl--terminal-tmux-alive-p)
+                     (lambda (_id)
+                       (error "must not synchronously query tmux"))))
+            (should (= 1 (enkan-repl--get-workspace-buffer-count-pure
+                          (list buffer1 buffer2)
+                          "01")))))
+      (dolist (buffer (list buffer1 buffer2))
+        (when (buffer-live-p buffer)
           (kill-buffer buffer))))))
 
 (provide 'enkan-repl-workspace-buffer-count-test)

--- a/test/enkan-repl-workspace-buffer-problem-test.el
+++ b/test/enkan-repl-workspace-buffer-problem-test.el
@@ -83,9 +83,9 @@ the second buffer gets named with <2> suffix instead of using the workspace ID."
     (should (equal '((1 . "er")) enkan-repl-session-list))
     (should (equal '((1 . "er")) (enkan-repl--ws-session-list)))
     
-    ;; Test that setup-window-eat-buffer-pure returns correct result
-    (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+    ;; Test that setup-window-terminal-buffer-pure returns correct result
+    (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'test-window 1
                      (enkan-repl--ws-session-list)
                      enkan-repl-target-directories)))
@@ -95,8 +95,8 @@ the second buffer gets named with <2> suffix instead of using the workspace ID."
         (should (consp result))
         (should (string-match-p "\\*ws:01 enkan:/path/to/er/\\*" (cdr result)))))))
 
-(ert-deftest test-setup-session-eat-buffer-returns-nil ()
-  "Test that setup-session-eat-buffer behaves correctly when session list is empty."
+(ert-deftest test-setup-session-terminal-buffer-returns-nil ()
+  "Test that setup-session-terminal-buffer behaves correctly when session list is empty."
   
   (let ((enkan-repl--current-workspace "01")
         (enkan-repl-session-list nil) ;; Empty session list
@@ -116,9 +116,9 @@ the second buffer gets named with <2> suffix instead of using the workspace ID."
                (lambda (buffer)
                  (error "Should not try to switch to buffer"))))
       
-      ;; Call enkan-repl--setup-session-eat-buffer with empty session list
-      (when (fboundp 'enkan-repl--setup-session-eat-buffer)
-        (enkan-repl--setup-session-eat-buffer 'test-window 1))
+      ;; Call enkan-repl--setup-session-terminal-buffer with empty session list
+      (when (fboundp 'enkan-repl--setup-session-terminal-buffer)
+        (enkan-repl--setup-session-terminal-buffer 'test-window 1))
       
       ;; Should show "No session registered" message
       (should (cl-find-if (lambda (msg)

--- a/test/enkan-repl-workspace-create-test.el
+++ b/test/enkan-repl-workspace-create-test.el
@@ -70,7 +70,7 @@
              ((symbol-function 'delete-other-windows) (lambda ()))
              ((symbol-function 'split-window-right) (lambda ()))
              ((symbol-function 'other-window) (lambda (n)))
-             ((symbol-function 'enkan-repl-start-eat) (lambda (&optional force)))
+             ((symbol-function 'enkan-repl-start-session) (lambda (&optional force)))
              ((symbol-function 'enkan-repl-open-project-input-file) (lambda ()))
              ((symbol-function 'message) (lambda (&rest args) nil)))
     ;; Execute enkan-repl-setup
@@ -118,7 +118,7 @@
       (should (string= (plist-get ws-state :current-project) "MyProject"))
       (should (equal (plist-get ws-state :project-aliases) '("alias1"))))))
 
-(ert-deftest test-enkan-repl--setup-window-eat-buffer-pure-workspace-context ()
+(ert-deftest test-enkan-repl--setup-window-terminal-buffer-pure-workspace-context ()
   "Test that window eat buffer name includes correct workspace ID."
   ;; Load window-layouts if exists
   (when (file-exists-p "/Users/sekine/dev/self/enkan-repl/examples/window-layouts.el")
@@ -129,8 +129,8 @@
         (session-list '((1 . "project-a")))
         ;; project-registry format: ((alias . (project-name . project-path)) ...)
         (project-registry '(("alias1" . ("project-a" . "/path/to")))))
-    (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+    (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'dummy-window 1 session-list project-registry)))
         (when result
           ;; Buffer name should include ws:01
@@ -141,8 +141,8 @@
         (session-list '((1 . "project-a")))
         ;; project-registry format: ((alias . (project-name . project-path)) ...)
         (project-registry '(("alias1" . ("project-a" . "/path/to")))))
-    (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+    (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'dummy-window 1 session-list project-registry)))
         (when result
           ;; Buffer name should include ws:02

--- a/test/enkan-repl-workspace-manual-switch-test.el
+++ b/test/enkan-repl-workspace-manual-switch-test.el
@@ -88,7 +88,7 @@
                  nil)))
       
       ;; Start eat (but save is mocked to do nothing)
-      (enkan-repl-start-eat)
+      (enkan-repl-start-session)
       
       ;; Session is registered in memory
       (should (equal '((1 . "er")) enkan-repl-session-list))

--- a/test/enkan-repl-workspace-real-scenario-test.el
+++ b/test/enkan-repl-workspace-real-scenario-test.el
@@ -35,7 +35,7 @@
                (lambda () (generate-new-buffer "*eat*")))
               ((symbol-function 'require)
                (lambda (_) t)))
-      (enkan-repl-start-eat))
+      (enkan-repl-start-session))
     (message "WS 01 sessions: %S" enkan-repl-session-list)
     
     (message "\n=== User creates WS 02 ===")
@@ -48,7 +48,7 @@
                (lambda () (generate-new-buffer "*eat*")))
               ((symbol-function 'require)
                (lambda (_) t)))
-      (enkan-repl-start-eat))
+      (enkan-repl-start-session))
     (message "WS 02 sessions: %S" enkan-repl-session-list)
     
     (message "\n=== User switches to WS 02 ===")
@@ -89,7 +89,7 @@
                (lambda () (generate-new-buffer "*eat*")))
               ((symbol-function 'require)
                (lambda (_) t)))
-      (enkan-repl-start-eat))
+      (enkan-repl-start-session))
     
     ;; Check states
     (let ((ws01-state (enkan-repl--get-workspace-state enkan-repl--workspaces "01"))

--- a/test/enkan-repl-workspace-session-list-test.el
+++ b/test/enkan-repl-workspace-session-list-test.el
@@ -74,8 +74,8 @@
     (should (equal '((1 . "er")) (enkan-repl--ws-session-list)))
     
     ;; Test buffer name generation
-    (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+    (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'test-window 1
                      (enkan-repl--ws-session-list)
                      enkan-repl-target-directories)))
@@ -135,9 +135,9 @@
                    (when (string-match "not found\\|No session" msg)
                      msg)))))
       
-      ;; Test setup-session-eat-buffer behavior
-      (when (fboundp 'enkan-repl--setup-session-eat-buffer)
-        (let ((msg (enkan-repl--setup-session-eat-buffer 'test-window 1)))
+      ;; Test setup-session-terminal-buffer behavior
+      (when (fboundp 'enkan-repl--setup-session-terminal-buffer)
+        (let ((msg (enkan-repl--setup-session-terminal-buffer 'test-window 1)))
           ;; Should show message about missing buffer or no session
           (should (or (string-match-p "not found" msg)
                       (string-match-p "No session" msg))))))))

--- a/test/enkan-repl-workspace-switch-layout-test.el
+++ b/test/enkan-repl-workspace-switch-layout-test.el
@@ -117,15 +117,15 @@
 (ert-deftest test-workspace-buffer-selection-pure ()
   "Test pure function buffer selection logic for workspaces."
   
-  ;; Test that enkan-repl--setup-window-eat-buffer-pure respects workspace ID
-  (when (fboundp 'enkan-repl--setup-window-eat-buffer-pure)
+  ;; Test that enkan-repl--setup-window-terminal-buffer-pure respects workspace ID
+  (when (fboundp 'enkan-repl--setup-window-terminal-buffer-pure)
     
     ;; Test with ws:01
     (let ((enkan-repl--current-workspace "01")
           (session-list '((1 . "er")))
           (project-registry '(("er-alias" . ("er" . "/path/to/er")))))
       
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'dummy-window 1 session-list project-registry)))
         (when result
           ;; Should return ws:01 buffer name
@@ -136,11 +136,74 @@
           (session-list '((1 . "er")))
           (project-registry '(("er-alias" . ("er" . "/path/to/er")))))
       
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'dummy-window 1 session-list project-registry)))
         (when result
           ;; Should return ws:02 buffer name
           (should (string-match-p "\\*ws:02 " (cdr result))))))))
+
+(ert-deftest test-workspace-layout-ignores-stray-tmux-mirrors ()
+  "C-M-l should ignore tmux mirrors that are not registered sessions."
+  (let* ((project-dir "/Users/sekine/dev/self/enkan-repl/")
+         (good (generate-new-buffer
+                (format "*ws:01 enkan:%s*" project-dir)))
+         (stray-1 (generate-new-buffer "*ws:01 enkan:/Users/sekine/*"))
+         (stray-2 (generate-new-buffer "*ws:01 enkan:/Users/sekine/*<2>"))
+         (enkan-repl--current-workspace "01")
+         (enkan-repl--current-project "enkan-repl")
+         (enkan-repl-session-list '((1 . "enkan-repl")))
+         (enkan-repl-target-directories
+          `(("er" . ("enkan-repl" . ,project-dir))))
+         (called nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer good
+            (setq-local enkan-repl--tmux-mirror-id "enkan-01:enkan-repl"))
+          (with-current-buffer stray-1
+            (setq-local enkan-repl--tmux-mirror-id "enkan-01:sekine"))
+          (with-current-buffer stray-2
+            (setq-local enkan-repl--tmux-mirror-id "enkan-01:sekine-2"))
+          (should (equal (list good)
+                         (enkan-repl--registered-session-buffers)))
+          (cl-letf (((symbol-function 'enkan-repl-setup-1session-layout)
+                     (lambda () (setq called 'one)))
+                    ((symbol-function 'enkan-repl-setup-2session-layout)
+                     (lambda () (setq called 'two)))
+                    ((symbol-function 'enkan-repl-setup-3session-layout)
+                     (lambda () (setq called 'three))))
+            (enkan-repl-setup-current-project-layout)
+            (should (eq called 'one))))
+      (dolist (buffer (list good stray-1 stray-2))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
+
+(ert-deftest test-workspace-layout-deduplicates-session-list-buffer ()
+  "C-M-l should not count duplicate session entries resolving to one buffer."
+  (let* ((project-dir "/Users/sekine/dev/self/enkan-repl/")
+         (good (generate-new-buffer
+                (format "*ws:01 enkan:%s*" project-dir)))
+         (enkan-repl--current-workspace "01")
+         (enkan-repl--current-project "enkan-repl")
+         (enkan-repl-session-list '((1 . "enkan-repl")
+                                    (2 . "enkan-repl")
+                                    (3 "enkan-repl" . 2)))
+         (enkan-repl-target-directories
+          `(("er" . ("enkan-repl" . ,project-dir))))
+         (called nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer good
+            (setq-local enkan-repl--tmux-mirror-id "enkan-01:enkan-repl"))
+          (should (equal (list good)
+                         (enkan-repl--registered-session-buffers)))
+          (cl-letf (((symbol-function 'enkan-repl-setup-1session-layout)
+                     (lambda () (setq called 'one)))
+                    ((symbol-function 'enkan-repl-setup-2session-layout)
+                     (lambda () (setq called 'two))))
+            (enkan-repl-setup-current-project-layout)
+            (should (eq called 'one))))
+      (when (buffer-live-p good)
+        (kill-buffer good)))))
 
 (provide 'enkan-repl-workspace-switch-layout-test)
 ;;; enkan-repl-workspace-switch-layout-test.el ends here

--- a/test/enkan-repl-workspace-target-directories-test.el
+++ b/test/enkan-repl-workspace-target-directories-test.el
@@ -48,7 +48,7 @@
       (enkan-repl--load-workspace-state test-ws1)
       
       ;; Test: In ws:01, should find er project path
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'dummy-window 1 
                      '((1 . "er"))
                      enkan-repl-target-directories)))
@@ -73,7 +73,7 @@
         (enkan-repl--load-workspace-state test-ws2)
         
         ;; Test: In ws:02, should find project-b path 
-        (let ((result (enkan-repl--setup-window-eat-buffer-pure
+        (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                        'dummy-window 1
                        '((1 . "project-b"))
                        enkan-repl-target-directories)))
@@ -95,7 +95,7 @@
           (enkan-repl--load-workspace-state test-ws1)
           
           ;; Test: After switching back to ws:01, should still find er project
-          (let ((result (enkan-repl--setup-window-eat-buffer-pure
+          (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                          'dummy-window 1
                          '((1 . "er"))
                          enkan-repl-target-directories)))
@@ -122,7 +122,7 @@
                  ;; Simulate buffer not existing
                  nil)))
       
-      (let ((result (enkan-repl--setup-window-eat-buffer-pure
+      (let ((result (enkan-repl--setup-window-terminal-buffer-pure
                      'dummy-window 1
                      '((1 . "er"))
                      enkan-repl-target-directories)))


### PR DESCRIPTION
## Summary
- add manual `enkan-repl-tmux-reattach` command to restore persisted workspace state only when explicitly invoked
- avoid force-refreshing every restored workspace during reattach; if state is already current, reattach now returns without refreshing
- add `enkan-repl-tmux-refresh-workspace` to explicitly recreate/refresh tmux mirror buffers for the current workspace
- bind refresh to `C-M-g` and reattach to `C-M-r` in `examples/keybinding.el`
- update `README.org` to document manual reattach, explicit workspace refresh, consult/minibuffer refresh deferral, and that startup reattach is not automatic

## Keybinding rationale
- `C-M-g`: refresh/update current workspace mirrors, using a lightweight repeatable key near the existing C-M workspace controls
- `C-M-r`: manual reattach/reconnect after Emacs restart, mnemonic for reattach/restore and intentionally separate from refresh

## Freeze investigation
- `enkan-repl-tmux-reattach` only matters if that command is invoked; it is not an automatic startup path.
- The always-on path is the tmux mirror idle timer. It skips hidden buffers, but `consult-buffer` preview can temporarily display a mirror buffer in a live window, which previously made it eligible for synchronous `tmux capture-pane` during minibuffer completion.
- Timer refresh now defers while the minibuffer is active, so consult preview/listing cannot trigger mirror capture. Explicit commands (`enkan-repl-tmux-refresh-current` / `enkan-repl-tmux-refresh-workspace`) still force refresh by design.

## Tests
- `make test`
- `make compile`
- `make checkdoc`