### PR TITLE
fix: update release workflow for protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Emacs 30.1
         uses: purcell/setup-emacs@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required for semantic-release to analyze all commits
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,9 +28,9 @@ jobs:
           version: '30.1'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24.10.0"
 
       - name: Install Node.js dependencies
         run: npm install

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -28,42 +28,6 @@ module.exports = {
 		],
 		// Generate release notes from commits
 		"@semantic-release/release-notes-generator",
-		// Generate and update CHANGELOG.md
-		[
-			"@semantic-release/changelog",
-			{
-				changelogFile: "CHANGELOG.md",
-			},
-		],
-		// Update version in enkan-repl.el and regenerate documentation
-		[
-			"@semantic-release/exec",
-			{
-				prepareCmd: [
-					// Update version in .el file
-					"emacs --batch --load scripts/bump-version.el -- ${nextRelease.version}",
-					// Regenerate precompiled constants for cheat-sheet performance (must be first)
-					"emacs --batch --load scripts/generate-constants.el --eval '(generate-cheat-sheet-constants)'",
-					// Regenerate documentation files with updated functions (uses constants)
-					"emacs --batch --load scripts/generate-docs.el --eval '(generate-all-docs)'",
-				].join(" && "),
-			},
-		],
-		// Commit the changes
-		[
-			"@semantic-release/git",
-			{
-				assets: [
-					"CHANGELOG.md",
-					"package.json",
-					"enkan-repl.el",
-					"README.org",
-					"enkan-repl-constants.el",
-				],
-				message:
-					"chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
-			},
-		],
 		// Create GitHub release
 		"@semantic-release/github",
 	],

--- a/README.org
+++ b/README.org
@@ -404,7 +404,7 @@ byte compilation,
 and documentation checks.
 
 ** Releases
-This project uses automated releases via [[https://semantic-release.gitbook.io/][semantic-release]]. New versions are automatically published to GitHub Releases and a [[file:CHANGELOG.md][CHANGELOG.md]] is generated based on Conventional Commits. You can find detailed release notes in the CHANGELOG.
+This project uses automated releases via [[https://semantic-release.gitbook.io/][semantic-release]]. New versions are automatically published to GitHub Releases based on Conventional Commits. You can find detailed release notes on the GitHub Releases page.
 
 *Note*: The `semantic-release` toolchain is used for development/release automation only. The Elisp package itself has no Node.js runtime dependencies and can be installed normally via MELPA.
 

--- a/package.json
+++ b/package.json
@@ -23,13 +23,10 @@
   "author": "phasetr <phasetr@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/commit-analyzer": "^11.0.0",
-    "@semantic-release/exec": "^6.0.3",
-    "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^9.2.6",
-    "@semantic-release/release-notes-generator": "^12.0.0",
-    "conventional-changelog-conventionalcommits": "^7.0.2",
-    "semantic-release": "^23.0.0"
+    "@semantic-release/commit-analyzer": "^13.0.1",
+    "@semantic-release/github": "^12.0.8",
+    "@semantic-release/release-notes-generator": "^14.1.1",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
+    "semantic-release": "^25.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- update GitHub Actions to Node 24-compatible checkout/setup-node versions
- run release workflow on Node 24.10.0 for semantic-release 25
- remove semantic-release prepare/git steps that pushed release commits directly to protected main
- update release docs to point to GitHub Releases instead of generated changelog commits

## Checks
- make check
- npm audit --json (0 vulnerabilities)
- node -e require('./.releaserc.js')
- git diff --check
- no .elc files