### PR TITLE
chore: tune buffer output limit

### DIFF
--- a/README.org
+++ b/README.org
@@ -310,6 +310,10 @@ same user-facing send / layout commands (=enkan-repl-send-line=,
   =enkan-repl-tmux-mirror-interval= seconds.
   Disable mirroring with =(setq enkan-repl-tmux-mirror nil)= if not
   desired.
+- Mirror refresh keeps a bounded recent view by default: 320 captured
+  lines, 240 displayed lines, 256 KiB of content, and 2048 characters
+  per line before truncation.  Large diff-like/noisy blocks are still
+  compacted.
 - Mirror buffers show refresh state in the header line
   (=refreshing=, =hidden=, =fresh=, =unchanged=, =closed=).
 - Run =M-x enkan-repl-tmux-refresh-workspace= to recreate or force

--- a/enkan-repl-terminal.el
+++ b/enkan-repl-terminal.el
@@ -569,19 +569,21 @@ latency when many background panes exist."
   :type 'integer
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-history-lines 160
+(defcustom enkan-repl-tmux-mirror-history-lines 320
   "Number of recent tmux lines to capture per refresh.
-The mirror is a lightweight status view, not a full transcript.  Keep this
-small enough that manual refresh remains cheap after a long idle period."
+The mirror is a bounded recent-status view, not a full transcript.  The
+default is large enough to preserve longer proposals while keeping manual
+refresh work bounded."
   :type 'integer
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-display-lines 80
-  "Maximum number of lines kept in a tmux mirror buffer."
+(defcustom enkan-repl-tmux-mirror-display-lines 240
+  "Maximum number of lines kept in a tmux mirror buffer.
+This limits the Emacs buffer after noisy output compaction."
   :type 'integer
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-max-chars (* 64 1024)
+(defcustom enkan-repl-tmux-mirror-max-chars (* 256 1024)
   "Maximum characters to apply to a tmux mirror buffer per refresh.
 When captured content is larger than this value, keep the tail of the
 capture.  This bounds main-thread work after the asynchronous tmux
@@ -599,8 +601,10 @@ process returns."
   :type 'integer
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-max-line-length 240
-  "Maximum line length shown verbatim in tmux mirror buffers."
+(defcustom enkan-repl-tmux-mirror-max-line-length 2048
+  "Maximum line length shown verbatim in tmux mirror buffers.
+This accommodates prose joined by `tmux capture-pane -J' while still
+truncating pathological single-line output."
   :type 'integer
   :group 'enkan-repl-terminal)
 

--- a/test/enkan-repl-terminal-test.el
+++ b/test/enkan-repl-terminal-test.el
@@ -556,6 +556,31 @@ documented opt-in alternative; see README."
                    (enkan-repl--terminal-tmux--tail-append
                     "abc" "def" nil))))
 
+(ert-deftest test-enkan-repl-tmux-mirror-default-limits ()
+  "Default tmux mirror limits should preserve useful proposal context."
+  (should (= 320 enkan-repl-tmux-mirror-history-lines))
+  (should (= 240 enkan-repl-tmux-mirror-display-lines))
+  (should (= (* 256 1024) enkan-repl-tmux-mirror-max-chars))
+  (should (= 2048 enkan-repl-tmux-mirror-max-line-length)))
+
+(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-proposal-defaults ()
+  "Default mirror preparation should keep a moderate proposal from the start."
+  (let ((content (test-enkan-repl-terminal--lines 1 200)))
+    (should (string-prefix-p "line 01"
+                             (enkan-repl--terminal-tmux--prepare-mirror-content
+                              content)))
+    (should (string-suffix-p "line 200"
+                             (enkan-repl--terminal-tmux--prepare-mirror-content
+                              content)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-joined-prose ()
+  "Default line limit should not truncate normal prose joined by capture-pane."
+  (let* ((sentence "This is a readable paragraph from a longer specification proposal. ")
+         (content (string-join (make-list 25 sentence) "")))
+    (should (string= content
+                     (enkan-repl--terminal-tmux--prepare-mirror-content
+                      content)))))
+
 (ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-tail-lines ()
   "Prepared tmux mirror content should keep only recent display lines."
   (let ((enkan-repl-tmux-mirror-display-lines 3)


### PR DESCRIPTION
## Summary
- Start discussion for tuning buffer output limits to preserve longer proposals while keeping load controlled.

## Notes
- Empty initial commit as requested before implementation.

## Test plan
- Not run yet; specification and implementation are pending.