### PR TITLE
refactor: drop excessive tmux mirror output reshaping (tmux-peek handles paging)

### DIFF
--- a/enkan-repl-terminal.el
+++ b/enkan-repl-terminal.el
@@ -634,7 +634,7 @@ refresh work bounded."
 
 (defcustom enkan-repl-tmux-mirror-display-lines 240
   "Maximum number of lines kept in a tmux mirror buffer.
-This limits the Emacs buffer after noisy output compaction."
+This bounds the Emacs buffer size; captured output is mirrored verbatim."
   :type 'integer
   :group 'enkan-repl-terminal)
 
@@ -643,23 +643,6 @@ This limits the Emacs buffer after noisy output compaction."
 When captured content is larger than this value, keep the tail of the
 capture.  This bounds main-thread work after the asynchronous tmux
 process returns."
-  :type 'integer
-  :group 'enkan-repl-terminal)
-
-(defcustom enkan-repl-tmux-mirror-compact-noisy-blocks t
-  "When non-nil, collapse large diff-like or very long output blocks."
-  :type 'boolean
-  :group 'enkan-repl-terminal)
-
-(defcustom enkan-repl-tmux-mirror-noisy-block-threshold 6
-  "Minimum consecutive noisy lines collapsed into one mirror summary line."
-  :type 'integer
-  :group 'enkan-repl-terminal)
-
-(defcustom enkan-repl-tmux-mirror-max-line-length 2048
-  "Maximum line length shown verbatim in tmux mirror buffers.
-This accommodates prose joined by `tmux capture-pane -J' while still
-truncating pathological single-line output."
   :type 'integer
   :group 'enkan-repl-terminal)
 
@@ -1253,75 +1236,6 @@ When MAX-CHARS is nil or non-positive, return the full concatenation."
          "\n"))
     content))
 
-(defun enkan-repl--terminal-tmux--max-line-length ()
-  "Return the configured mirror line length limit, or nil."
-  (and (integerp enkan-repl-tmux-mirror-max-line-length)
-       (> enkan-repl-tmux-mirror-max-line-length 0)
-       enkan-repl-tmux-mirror-max-line-length))
-
-(defun enkan-repl--terminal-tmux--truncate-line (line max-length)
-  "Return LINE shortened to MAX-LENGTH characters when needed."
-  (if (and max-length (> (length line) max-length))
-      (format "%s [enkan-repl: omitted %d chars]"
-              (substring line 0 max-length)
-              (- (length line) max-length))
-    line))
-
-(defun enkan-repl--terminal-tmux--noisy-line-p (line)
-  "Return non-nil when LINE looks like generated diff/code noise."
-  (let ((max-length (enkan-repl--terminal-tmux--max-line-length)))
-    (or (and max-length
-             (> (length line) max-length))
-        (string-match-p
-         (rx string-start (* space)
-             (or "diff --git" "index " "@@ " "+++ " "--- "
-                 "```" "~~~"))
-         line)
-        (string-match-p
-         (rx string-start (* space) (or "+" "-")
-             (not (any "\n")))
-         line))))
-
-(defun enkan-repl--terminal-tmux--noisy-block-threshold ()
-  "Return the configured noisy block threshold."
-  (if (and (integerp enkan-repl-tmux-mirror-noisy-block-threshold)
-           (> enkan-repl-tmux-mirror-noisy-block-threshold 0))
-      enkan-repl-tmux-mirror-noisy-block-threshold
-    6))
-
-(defun enkan-repl--terminal-tmux--flush-noisy-lines (lines output)
-  "Append compacted or verbatim noisy LINES to OUTPUT."
-  (let ((threshold (enkan-repl--terminal-tmux--noisy-block-threshold)))
-    (if (>= (length lines) threshold)
-        (cons (format "[enkan-repl: omitted %d noisy/diff line(s)]"
-                      (length lines))
-              output)
-      (append lines output))))
-
-(defun enkan-repl--terminal-tmux--compact-noisy-content (content)
-  "Collapse large noisy blocks in CONTENT."
-  (if (not enkan-repl-tmux-mirror-compact-noisy-blocks)
-      content
-    (let ((output nil)
-          (noisy nil)
-          (max-length (enkan-repl--terminal-tmux--max-line-length)))
-      (dolist (line (split-string content "\n"))
-        (if (enkan-repl--terminal-tmux--noisy-line-p line)
-            (push (enkan-repl--terminal-tmux--truncate-line line max-length)
-                  noisy)
-          (let ((line (enkan-repl--terminal-tmux--truncate-line
-                       line max-length)))
-            (when noisy
-              (setq output
-                    (enkan-repl--terminal-tmux--flush-noisy-lines
-                     noisy output))
-              (setq noisy nil))
-            (push line output))))
-      (when noisy
-        (setq output
-              (enkan-repl--terminal-tmux--flush-noisy-lines noisy output)))
-      (string-join (reverse output) "\n"))))
-
 (defun enkan-repl--terminal-tmux--prepare-mirror-content (content)
   "Return bounded, display-ready tmux mirror CONTENT."
   (let* ((max-chars (and (integerp enkan-repl-tmux-mirror-max-chars)
@@ -1331,7 +1245,6 @@ When MAX-CHARS is nil or non-positive, return the full concatenation."
                            (> (length content) max-chars))
                       (substring content (- max-chars))
                     content)))
-    (setq content (enkan-repl--terminal-tmux--compact-noisy-content content))
     (setq content
           (enkan-repl--terminal-tmux--tail-lines
            content enkan-repl-tmux-mirror-display-lines))

--- a/test/enkan-repl-terminal-test.el
+++ b/test/enkan-repl-terminal-test.el
@@ -615,8 +615,7 @@ documented opt-in alternative; see README."
   "Default tmux mirror limits should preserve useful proposal context."
   (should (= 320 enkan-repl-tmux-mirror-history-lines))
   (should (= 240 enkan-repl-tmux-mirror-display-lines))
-  (should (= (* 256 1024) enkan-repl-tmux-mirror-max-chars))
-  (should (= 2048 enkan-repl-tmux-mirror-max-line-length)))
+  (should (= (* 256 1024) enkan-repl-tmux-mirror-max-chars)))
 
 (ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-proposal-defaults ()
   "Default mirror preparation should keep a moderate proposal from the start."
@@ -639,56 +638,40 @@ documented opt-in alternative; see README."
 (ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-tail-lines ()
   "Prepared tmux mirror content should keep only recent display lines."
   (let ((enkan-repl-tmux-mirror-display-lines 3)
-        (enkan-repl-tmux-mirror-max-chars nil)
-        (enkan-repl-tmux-mirror-compact-noisy-blocks nil))
+        (enkan-repl-tmux-mirror-max-chars nil))
     (should (string= "line 03\nline 04\nline 05"
                      (enkan-repl--terminal-tmux--prepare-mirror-content
                       (test-enkan-repl-terminal--lines 1 5))))))
 
-(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-compacts-diff ()
-  "Prepared tmux mirror content should collapse large diff-like blocks."
+(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-diff-verbatim ()
+  "Diff-like blocks should be mirrored verbatim now tmux-peek handles paging."
   (let ((enkan-repl-tmux-mirror-display-lines 20)
         (enkan-repl-tmux-mirror-max-chars nil)
-        (enkan-repl-tmux-mirror-compact-noisy-blocks t)
-        (enkan-repl-tmux-mirror-noisy-block-threshold 3))
-    (should (string= "message before\n[enkan-repl: omitted 4 noisy/diff line(s)]\nmessage after"
+        (content (string-join
+                  '("message before"
+                    "+added line"
+                    "-removed line"
+                    "@@ hunk"
+                    "diff --git a/file b/file"
+                    "message after")
+                  "\n")))
+    (should (string= content
                      (enkan-repl--terminal-tmux--prepare-mirror-content
-                      (string-join
-                       '("message before"
-                         "+added line"
-                         "-removed line"
-                         "@@ hunk"
-                         "diff --git a/file b/file"
-                         "message after")
-                       "\n"))))))
+                      content)))))
 
-(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-short-noisy-order ()
-  "Short noisy blocks should stay readable and preserve line order."
+(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-long-lines-verbatim ()
+  "Very long single lines should no longer be truncated by the mirror."
   (let ((enkan-repl-tmux-mirror-display-lines 20)
         (enkan-repl-tmux-mirror-max-chars nil)
-        (enkan-repl-tmux-mirror-compact-noisy-blocks t)
-        (enkan-repl-tmux-mirror-noisy-block-threshold 3))
-    (should (string= "message before\n+added\n-removed\nmessage after"
+        (content (string-join
+                  (list "before"
+                        "0123456789abcdef"
+                        "abcdefghijklmnop"
+                        "after")
+                  "\n")))
+    (should (string= content
                      (enkan-repl--terminal-tmux--prepare-mirror-content
-                      (string-join
-                       '("message before" "+added" "-removed" "message after")
-                       "\n"))))))
-
-(ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-compacts-long-lines ()
-  "Repeated very long lines should be treated as noisy output."
-  (let ((enkan-repl-tmux-mirror-display-lines 20)
-        (enkan-repl-tmux-mirror-max-chars nil)
-        (enkan-repl-tmux-mirror-compact-noisy-blocks t)
-        (enkan-repl-tmux-mirror-noisy-block-threshold 2)
-        (enkan-repl-tmux-mirror-max-line-length 8))
-    (should (string= "before\n[enkan-repl: omitted 2 noisy/diff line(s)]\nafter"
-                     (enkan-repl--terminal-tmux--prepare-mirror-content
-                      (string-join
-                       (list "before"
-                             "0123456789abcdef"
-                             "abcdefghijklmnop"
-                             "after")
-                       "\n"))))))
+                      content)))))
 
 (ert-deftest test-enkan-repl--terminal-tmux--mirror-refresh-sticks-to-bottom ()
   "A tmux mirror window at the bottom should remain at the bottom after refresh."
@@ -851,8 +834,7 @@ documented opt-in alternative; see README."
           (setq-local enkan-repl--tmux-mirror-id "enkan-01:p")
           (insert (make-string 10000 ?x))
           (let ((enkan-repl-tmux-mirror-display-lines 80)
-                (enkan-repl-tmux-mirror-max-chars (* 64 1024))
-                (enkan-repl-tmux-mirror-compact-noisy-blocks t))
+                (enkan-repl-tmux-mirror-max-chars (* 64 1024)))
             (cl-letf (((symbol-function 'replace-buffer-contents)
                        (lambda (&rest _)
                          (error "must not diff mirror content"))))


### PR DESCRIPTION
## Intent
Previously the tmux mirror buffer applied aggressive output reshaping: it collapsed diff/code-like "noisy" blocks into a single summary line and truncated very long lines. Now that tmux-peek sits in front of the mirror, paging and filtering of output are handled by tmux-peek, so this reshaping is counterproductive — it hides the original output and drops content behind `[enkan-repl: omitted ...]` markers.

This PR removes the excessive output reshaping from the enkan-repl tmux mirror so the mirror reflects captured content verbatim.

## Not an enkan-repl scrollback issue
Confirmed that the limited display amount (small output in `tmux-peek-session-list`) is not caused by enkan-repl:
- enkan-repl never sets `history-limit` on `new-session` / `new-window`.
- All tmux interaction is read-only `capture-pane -p`; it never calls `clear-history`, `set-option history-limit`, `resize-pane`, or `pipe-pane`.
- Mirror reshaping only transformed the captured string on the Emacs side; it never touched tmux pane content or scrollback.

The display-amount limitation therefore belongs to tmux configuration / tmux-peek capture range and is tracked separately.

## Changes
`enkan-repl-terminal.el`
- Remove defcustoms:
  - `enkan-repl-tmux-mirror-compact-noisy-blocks`
  - `enkan-repl-tmux-mirror-noisy-block-threshold`
  - `enkan-repl-tmux-mirror-max-line-length`
- Remove functions:
  - `enkan-repl--terminal-tmux--max-line-length`
  - `enkan-repl--terminal-tmux--truncate-line`
  - `enkan-repl--terminal-tmux--noisy-line-p`
  - `enkan-repl--terminal-tmux--noisy-block-threshold`
  - `enkan-repl--terminal-tmux--flush-noisy-lines`
  - `enkan-repl--terminal-tmux--compact-noisy-content`
- Drop the compaction call from `enkan-repl--terminal-tmux--prepare-mirror-content`.

## Kept
Character/line bounds are retained as main-thread work and buffer-size limits, not output reshaping:
- `enkan-repl-tmux-mirror-max-chars`
- `enkan-repl-tmux-mirror-display-lines`
- `enkan-repl-tmux-mirror-history-lines`

## Test plan
- `make check` (281 tests, 281 passed, 0 unexpected; lint + format + compile + checkdoc)
- Replaced compaction behavior tests with verbatim-mirroring tests:
  - `test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-diff-verbatim`
  - `test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-long-lines-verbatim`
- Verified no remaining references to the removed symbols via grep.

## Related PRs
- #68 chore: tune buffer output limit
- #66 / #67 tmux mirror adjustments
- #60 (closed) suppress auxiliary buffer pop-ups
