### PR TITLE
feat: disable tmux alternate screen so capture-pane retrieves full AI output

### DIFF
--- a/enkan-repl-terminal.el
+++ b/enkan-repl-terminal.el
@@ -445,6 +445,17 @@ names such as dr-remote.jp as pane selectors."
   (or (enkan-repl--terminal-tmux--id-pane id)
       id))
 
+(defun enkan-repl--terminal-tmux--disable-alternate-screen (pane)
+  "Disable the tmux alternate screen for PANE's window when configured.
+PANE is a tmux pane id such as \"%29\".  This is applied right after pane
+creation, before any AI CLI starts, so the CLI renders into the normal
+screen and tmux keeps its output in scrollback."
+  (when (and enkan-repl-tmux-disable-alternate-screen
+             (stringp pane)
+             (not (string-empty-p pane)))
+    (enkan-repl--terminal-tmux--call
+     (list "set-option" "-w" "-t" pane "alternate-screen" "off"))))
+
 (defun enkan-repl--terminal-tmux-start (dir)
   "Tmux backend: start a new session/window in DIR for current workspace.
 Ensures the workspace's tmux session exists (creating it on demand) and
@@ -464,6 +475,7 @@ target identifier (e.g. \"enkan-01:lat\")."
                    t)))
         (unless (and pane (not (string-empty-p pane)))
           (user-error "Tmux new-session failed for %s" session))
+        (enkan-repl--terminal-tmux--disable-alternate-screen pane)
         (enkan-repl--terminal-tmux--make-id session base pane)))
      ;; Session exists: add a new window with a non-colliding name.
      (t
@@ -474,6 +486,7 @@ target identifier (e.g. \"enkan-01:lat\")."
                      t)))
           (unless (and pane (not (string-empty-p pane)))
             (user-error "Tmux new-window failed for %s:%s" session win))
+          (enkan-repl--terminal-tmux--disable-alternate-screen pane)
           (enkan-repl--terminal-tmux--make-id session win pane)))))))
 
 (defun enkan-repl--terminal-tmux-send (id text &optional newline)
@@ -651,6 +664,18 @@ process returns."
 This bounds how long `enkan-repl-tmux-refresh-current' can wait on a stuck
 tmux capture process."
   :type 'number
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-disable-alternate-screen t
+  "When non-nil, disable the tmux alternate screen for created panes.
+Many AI CLIs render their conversation into the terminal alternate screen,
+which tmux does not keep in its scrollback (its `history_size' stays 0).
+`tmux capture-pane' can then only return the visible viewport, so external
+viewers such as tmux-peek see just the last few lines instead of the whole
+conversation.  Disabling the alternate screen makes those CLIs render into
+the normal screen so tmux retains the full scrollback and capture returns
+the complete output."
+  :type 'boolean
   :group 'enkan-repl-terminal)
 
 (defvar-local enkan-repl--tmux-mirror-id nil

--- a/test/enkan-repl-terminal-test.el
+++ b/test/enkan-repl-terminal-test.el
@@ -82,11 +82,51 @@ documented opt-in alternative; see README."
       (let ((id (enkan-repl--terminal-tmux-start "/repo/dr-remote.jp/")))
         (should (string= "enkan-01:dr-remote.jp|%12" id))
         (should (string= "%12" (enkan-repl--terminal-tmux--target id)))
-        (should (equal '(("new-session" "-d" "-P" "-F" "#{pane_id}"
-                          "-s" "enkan-01" "-c" "/repo/dr-remote.jp/"
-                          "-n" "dr-remote.jp")
-                         t)
-                       (car calls)))))))
+        (should (member '(("new-session" "-d" "-P" "-F" "#{pane_id}"
+                           "-s" "enkan-01" "-c" "/repo/dr-remote.jp/"
+                           "-n" "dr-remote.jp")
+                          t)
+                        calls))))))
+
+(ert-deftest test-enkan-repl--terminal-tmux-start-disables-alternate-screen ()
+  "Starting a session should disable the tmux alternate screen for the pane."
+  (let ((enkan-repl--current-workspace "01")
+        (enkan-repl-tmux-session-prefix "enkan-")
+        (enkan-repl-tmux-disable-alternate-screen t)
+        calls)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--ensure-bell-monitor)
+               (lambda () nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--has-session)
+               (lambda (_session) nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--call)
+               (lambda (args &optional capture)
+                 (push (list args capture) calls)
+                 (when (member "new-session" args)
+                   "%12"))))
+      (enkan-repl--terminal-tmux-start "/repo/proj/")
+      (should (member '(("set-option" "-w" "-t" "%12" "alternate-screen" "off")
+                        nil)
+                      calls)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux-start-keeps-alternate-screen-when-off ()
+  "Disabling the option should keep tmux alternate screen untouched."
+  (let ((enkan-repl--current-workspace "01")
+        (enkan-repl-tmux-session-prefix "enkan-")
+        (enkan-repl-tmux-disable-alternate-screen nil)
+        calls)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--ensure-bell-monitor)
+               (lambda () nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--has-session)
+               (lambda (_session) nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--call)
+               (lambda (args &optional capture)
+                 (push (list args capture) calls)
+                 (when (member "new-session" args)
+                   "%12"))))
+      (enkan-repl--terminal-tmux-start "/repo/proj/")
+      (should-not (cl-find "set-option" calls
+                           :key (lambda (c) (car (car c)))
+                           :test #'equal)))))
 
 (ert-deftest test-enkan-repl--terminal-tmux--capture-pane-async-targets-pane-id ()
   "Mirror capture for dr-remote.jp should pass %pane_id to tmux -t."


### PR DESCRIPTION
## Intent
Output captured through tmux-peek (and any `tmux capture-pane` consumer) showed only the last few lines of an AI conversation. For example, when the AI posted items 1..6, only item 6 was retrievable.

Root cause (verified on macOS / tmux 3.6a): AI CLIs such as Claude Code and codex render their conversation into the terminal **alternate screen**. tmux does not keep the alternate screen in scrollback, so `history_size` stays 0 and `capture-pane` can only return the visible viewport (~24 lines). Panes that happened to have normal-screen history returned the full content; panes in alternate-screen mode with `history_size=0` returned only the viewport, which is the intermittent "only the last message" symptom.

A controlled experiment confirmed the mechanism:

| setting | history_size after quit | captured content lines |
| --- | --- | --- |
| `alternate-screen on` (default) | 0 | ~2 |
| `alternate-screen off` | 23 | 25 |

This cannot be fixed in a read-only viewer: tmux-peek cannot recover scrollback that tmux never stored. The fix must make the CLI render into the normal screen.

## Changes
- Add `enkan-repl-tmux-disable-alternate-screen` (default `t`).
- Right after creating a pane (new-session and new-window), and before any AI CLI starts, run `set-option -w -t <pane> alternate-screen off` so the CLI renders into the normal screen and tmux retains the full scrollback that `capture-pane -S -` can retrieve.

## Notes
- Applies to panes enkan-repl creates from now on; already-running panes must be restarted to take effect.
- With the alternate screen disabled, full-screen TUIs (vim, less, htop) leave their rendered content in scrollback instead of restoring the previous screen on exit. Set `enkan-repl-tmux-disable-alternate-screen` to nil to opt out.

## Test plan
- `make check` (283 tests, 283 passed, 0 unexpected; lint + format + compile + checkdoc)
- New tests:
  - `test-enkan-repl--terminal-tmux-start-disables-alternate-screen`
  - `test-enkan-repl--terminal-tmux-start-keeps-alternate-screen-when-off`
- Updated `test-enkan-repl--terminal-tmux-start-dotted-window-uses-pane-id` for the added set-option call.
