### PR TITLE
feat: apply alternate-screen off on tmux reattach for full capture

### DIFF
--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -110,6 +110,8 @@
 (declare-function enkan-repl--terminal-tmux-alive-p "enkan-repl-terminal" (id))
 (declare-function enkan-repl--terminal-tmux-mirror-buffer-alive-p "enkan-repl-terminal" (buffer))
 (declare-function enkan-repl--terminal-tmux--mirror-make "enkan-repl-terminal" (id &optional defer-refresh path))
+(declare-function enkan-repl--terminal-tmux--target "enkan-repl-terminal" (id))
+(declare-function enkan-repl--terminal-tmux--disable-alternate-screen "enkan-repl-terminal" (pane))
 (declare-function enkan-repl--terminal-tmux--list-windows "enkan-repl-terminal" (session))
 (declare-function enkan-repl--terminal-tmux--list-window-cwds "enkan-repl-terminal" (session))
 (declare-function enkan-repl--terminal-tmux--list-window-info "enkan-repl-terminal" (session))
@@ -667,7 +669,7 @@ cwd values.  PERSISTED entries with aliases not present in LIVE are retained."
                       alias project-aliases)
                      (cdr (cdr entry)))))
        aliases live))
-	     (t live))))
+     (t live))))
 
 (defun enkan-repl--tmux-reattach-normalize-session-list (state live target-directories)
   "Return session list for STATE reconciled with LIVE tmux data.
@@ -783,6 +785,29 @@ Returns the total number of mirror buffers ensured."
                 (setq total (1+ total))))))
       (setq enkan-repl--current-workspace previous-workspace))))
 
+(defun enkan-repl--tmux-reattach-disable-alternate-screen (workspace-ids)
+  "Disable the tmux alternate screen for live panes in WORKSPACE-IDS.
+At session creation `enkan-repl--terminal-tmux-start' already disables the
+alternate screen, but reattach reconnects to pre-existing panes, so apply it
+here too.  This lets `tmux capture-pane' (and external viewers such as
+tmux-peek) retrieve full pane output instead of only the visible viewport.
+The program in a pane decides its rendering mode at startup, so a running
+full-screen CLI must be restarted for the change to take effect.
+
+Returns the number of panes processed."
+  (if (not (eq enkan-repl-terminal-backend 'tmux))
+      0
+    (let ((previous-workspace enkan-repl--current-workspace)
+          (total 0))
+      (unwind-protect
+          (dolist (workspace-id workspace-ids total)
+            (setq enkan-repl--current-workspace workspace-id)
+            (dolist (id (or (enkan-repl--terminal-list) nil))
+              (enkan-repl--terminal-tmux--disable-alternate-screen
+               (enkan-repl--terminal-tmux--target id))
+              (setq total (1+ total))))
+        (setq enkan-repl--current-workspace previous-workspace)))))
+
 ;;;###autoload
 (defun enkan-repl-tmux-reattach (&optional file)
   "Reconnect Emacs state to live tmux sessions.
@@ -827,6 +852,7 @@ This command is intentionally manual; enkan-repl does not reattach on load."
                         live-workspaces)))
           (setq enkan-repl--current-workspace current-id)
           (enkan-repl--load-workspace-state current-id)
+          (enkan-repl--tmux-reattach-disable-alternate-screen restored-ids)
           (message
            "Already reattached to %d workspace(s), ensured %d tmux mirror buffer(s)"
            (length loaded-workspaces)
@@ -840,6 +866,7 @@ This command is intentionally manual; enkan-repl does not reattach on load."
                       live-workspaces)))
         (setq enkan-repl--current-workspace current-id)
         (enkan-repl--load-workspace-state current-id)
+        (enkan-repl--tmux-reattach-disable-alternate-screen restored-ids)
         (when (fboundp 'enkan-repl-state-save)
           (ignore-errors (enkan-repl-state-save file)))
         (message
@@ -1650,7 +1677,7 @@ Returns non-nil when sessions were restored."
                     (enkan-repl--get-project-info-from-directories
                      alias enkan-repl-target-directories))
                    (target-project (or (and (consp project-info)
-                                             (car project-info))
+                                            (car project-info))
                                        current-project))
                    (instance (or (enkan-repl--target-alias-instance-for-path
                                   alias path)

--- a/test/enkan-repl-core-test.el
+++ b/test/enkan-repl-core-test.el
@@ -108,6 +108,8 @@
                (lambda ()
                  (list (format "enkan-%s:window"
                                enkan-repl--current-workspace))))
+              ((symbol-function 'enkan-repl--terminal-tmux--disable-alternate-screen)
+               (lambda (_pane) nil))
               ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
                (lambda (id &optional defer-refresh path)
                  (push (list enkan-repl--current-workspace
@@ -154,6 +156,8 @@
               ((symbol-function 'enkan-repl--terminal-list)
                (lambda ()
                  (list "enkan-03:enkan-repl" "enkan-03:worker-2")))
+              ((symbol-function 'enkan-repl--terminal-tmux--disable-alternate-screen)
+               (lambda (_pane) nil))
               ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
                (lambda (id &optional defer-refresh path)
                  (push (list enkan-repl--current-workspace
@@ -214,6 +218,8 @@
               ((symbol-function 'enkan-repl--terminal-list)
                (lambda ()
                  '("enkan-04:proj" "enkan-04:proj-2")))
+              ((symbol-function 'enkan-repl--terminal-tmux--disable-alternate-screen)
+               (lambda (_pane) nil))
               ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
                (lambda (id &optional defer-refresh path)
                  (push (list id defer-refresh path) ensured-workspaces)
@@ -253,6 +259,8 @@
               ((symbol-function 'enkan-repl--terminal-list)
                (lambda ()
                  '("enkan-06:foo-2")))
+              ((symbol-function 'enkan-repl--terminal-tmux--disable-alternate-screen)
+               (lambda (_pane) nil))
               ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
                (lambda (id &optional _defer-refresh _path) id))
               ((symbol-function 'enkan-repl-state-save)
@@ -502,6 +510,8 @@
                (lambda ()
                  (list (format "enkan-%s:window"
                                enkan-repl--current-workspace))))
+              ((symbol-function 'enkan-repl--terminal-tmux--disable-alternate-screen)
+               (lambda (_pane) nil))
               ((symbol-function 'enkan-repl--terminal-tmux--mirror-make)
                (lambda (id &optional defer-refresh path)
                  (push (list enkan-repl--current-workspace
@@ -659,6 +669,33 @@
       ;; Cleanup
       (when (file-exists-p test-file)
         (delete-file test-file)))))
+
+(ert-deftest test-enkan-repl--tmux-reattach-disable-alternate-screen ()
+  "Reattach should disable the alternate screen for each live workspace pane."
+  (let ((enkan-repl-terminal-backend 'tmux)
+        (enkan-repl--current-workspace "init")
+        targets)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-list)
+               (lambda ()
+                 (list (format "enkan-%s:w|%%%s"
+                               enkan-repl--current-workspace
+                               enkan-repl--current-workspace))))
+              ((symbol-function 'enkan-repl--terminal-tmux--disable-alternate-screen)
+               (lambda (pane) (push pane targets))))
+      (let ((count (enkan-repl--tmux-reattach-disable-alternate-screen
+                    '("01" "02"))))
+        (should (= 2 count))
+        (should (equal '("%02" "%01") targets))
+        (should (string= "init" enkan-repl--current-workspace))))))
+
+(ert-deftest test-enkan-repl--tmux-reattach-disable-alternate-screen-non-tmux ()
+  "Disabling the alternate screen is a no-op for non-tmux backends."
+  (let ((enkan-repl-terminal-backend 'eat)
+        called)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--disable-alternate-screen)
+               (lambda (_pane) (setq called t))))
+      (should (= 0 (enkan-repl--tmux-reattach-disable-alternate-screen '("01"))))
+      (should-not called))))
 
 (provide 'enkan-repl-core-test)
 ;;; enkan-repl-core-test.el ends here


### PR DESCRIPTION
## Intent
#73 disables the tmux alternate screen only at pane creation (`enkan-repl--terminal-tmux-start`). The common workflow is persistent tmux sessions plus `enkan-repl-tmux-reattach`, which reconnects to pre-existing panes and never runs the creation path, so reattached panes keep the alternate screen on. `tmux capture-pane` (and external viewers such as tmux-peek) then return only the visible viewport.

Verified that with `alternate-screen off` a real Claude Code 2.1.185 session renders to the normal screen and `capture-pane -S -` retrieves the full output, so this generalises to codex and ordinary shells too.

## Changes (planned)
- Add `enkan-repl--tmux-reattach-disable-alternate-screen` and call it from both branches of `enkan-repl-tmux-reattach`, applying `alternate-screen off` to every live pane in the restored workspaces.

## Notes
- A program decides its rendering mode at startup, so a running full-screen CLI must be restarted for the change to take effect; plain shells benefit immediately. Past alternate-screen content already lost is not recoverable.

## Test plan
- `make check`
- New unit tests for the reattach helper (tmux and non-tmux backends).

Empty initial commit; implementation lands on this branch.
