### PR TITLE
feat: improve tmux mirror chat-history capture and add clear-input

### DIFF
--- a/enkan-repl-constants.el
+++ b/enkan-repl-constants.el
@@ -20,6 +20,7 @@
     ("enkan-repl-send-3" . "Send \\\\='3\\\\=' to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-send-4" . "Send \\\\='4\\\\=' to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-send-5" . "Send \\\\='5\\\\=' to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
+    ("enkan-repl-clear-input" . "Clear the input field of the target enkan session buffer with optional PFX. Sends C-u (kill to beginning of line) to the target CLI so text mistakenly typed into the wrong workspace's input box can be removed without submitting it.  No Enter is sent. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-recenter-bottom" . "Recenter all enkan terminal buffers at bottom.  Category: Utilities")
     ("enkan-repl-open-project-input-file" . "Open or create project input file for DIRECTORY. If DIRECTORY is nil, use current `default-directory'. If project input file exists, open it directly. If not exists, create from template then open.  Category: Utilities")
     ("enkan-repl-start-session" . "Start a terminal session in the current directory. This is the backend-neutral session starter.  It works with both the eat and tmux terminal backends configured by `enkan-repl-terminal-backend'. FORCE is accepted for interactive compatibility and currently ignored; the command always starts a new session.  Category: Session Controller")
@@ -36,7 +37,7 @@
 Each element is a cons cell (FUNCTION-NAME . DESCRIPTION).")
 
 (defconst enkan-repl-cheat-sheet-function-count
-  21
+  22
   "Number of functions in cheat-sheet.")
 
 (provide 'enkan-repl-constants)

--- a/enkan-repl-terminal.el
+++ b/enkan-repl-terminal.el
@@ -456,6 +456,16 @@ screen and tmux keeps its output in scrollback."
     (enkan-repl--terminal-tmux--call
      (list "set-option" "-w" "-t" pane "alternate-screen" "off"))))
 
+(defun enkan-repl--terminal-tmux--apply-history-limit ()
+  "Set the global tmux `history-limit' when `enkan-repl-tmux-history-limit'.
+tmux fixes a pane's scrollback size at creation time, so this must run before
+`new-session'/`new-window' for the resulting panes to keep that many lines."
+  (when (and (integerp enkan-repl-tmux-history-limit)
+             (> enkan-repl-tmux-history-limit 0))
+    (enkan-repl--terminal-tmux--call
+     (list "set-option" "-g" "history-limit"
+           (number-to-string enkan-repl-tmux-history-limit)))))
+
 (defun enkan-repl--terminal-tmux-start (dir)
   "Tmux backend: start a new session/window in DIR for current workspace.
 Ensures the workspace's tmux session exists (creating it on demand) and
@@ -466,6 +476,7 @@ target identifier (e.g. \"enkan-01:lat\")."
          (base (enkan-repl--terminal-tmux--derive-base-name dir))
          (cdir (expand-file-name dir)))
     (enkan-repl--terminal-tmux--ensure-bell-monitor)
+    (enkan-repl--terminal-tmux--apply-history-limit)
     (cond
      ;; Session does not exist: create it with the first window in DIR.
      ((not (enkan-repl--terminal-tmux--has-session session))
@@ -637,40 +648,46 @@ latency when many background panes exist."
   :type 'integer
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-history-lines 320
-  "Number of recent tmux lines to capture per refresh.
-The mirror is a bounded recent-status view, not a full transcript.  The
-default is large enough to preserve longer proposals while keeping manual
-refresh work bounded."
+(defcustom enkan-repl-tmux-mirror-history-lines 10000
+  "Number of tmux scrollback lines to capture per refresh (the `-S' depth).
+With the alternate screen disabled (see
+`enkan-repl-tmux-disable-alternate-screen'), tmux keeps the real, already
+de-duplicated conversation in its own scrollback, and `tmux capture-pane -S
+-N' returns it directly.  This is the depth of that read; keep it large enough
+to cover the chat history you want to see.  The pane must actually retain that
+many lines — see `enkan-repl-tmux-history-limit'."
   :type 'integer
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-display-lines 240
-  "Maximum number of lines kept in a tmux mirror buffer.
-This bounds the Emacs buffer size; captured output is mirrored verbatim."
+(defcustom enkan-repl-tmux-mirror-display-lines 10000
+  "Maximum number of lines kept and shown in a tmux mirror buffer.
+This bounds the Emacs buffer size; captured output is mirrored verbatim.
+Set it as large as the chat history you want visible; it is capped in
+practice by `enkan-repl-tmux-mirror-history-lines' (capture depth) and
+`enkan-repl-tmux-mirror-max-chars'."
   :type 'integer
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-max-chars (* 256 1024)
+(defcustom enkan-repl-tmux-mirror-max-chars (* 4 1024 1024)
   "Maximum characters to apply to a tmux mirror buffer per refresh.
 When captured content is larger than this value, keep the tail of the
 capture.  This bounds main-thread work after the asynchronous tmux
-process returns."
+process returns.  Keep it large enough that it does not truncate
+`enkan-repl-tmux-mirror-display-lines' lines (roughly display-lines times
+the average line width)."
   :type 'integer
   :group 'enkan-repl-terminal)
 
-(defcustom enkan-repl-tmux-mirror-accumulate t
+(defcustom enkan-repl-tmux-mirror-accumulate nil
   "When non-nil, accumulate tmux mirror content by appending new lines.
-Each `tmux capture-pane' returns only whatever tmux currently holds (its
-scrollback plus the visible viewport).  Full-screen AI CLIs (Claude Code,
-codex) redraw their conversation in place, so a single capture often exposes
-just a fraction of the chat history and the mirror would otherwise shrink to
-that viewport.  With accumulation on, each capture is merged into a growing
-transcript: the overlap between the accumulated tail and the new capture head
-is detected and only genuinely new lines are appended, so the mirror reliably
-keeps up to `enkan-repl-tmux-mirror-display-lines' lines of history regardless
-of tmux scrollback limits.  When nil, the mirror is replaced with each
-snapshot (legacy behavior)."
+DISABLED BY DEFAULT.  This merges successive `tmux capture-pane' viewports
+into a growing transcript by overlap detection.  It works only when the pane
+scrolls cleanly line by line.  Full-screen AI CLIs (Claude Code, codex) redraw
+their viewport in place, so consecutive captures share no clean scroll overlap
+and the whole viewport is appended every refresh — producing duplicated frames
+that evict real history.  Prefer nil and read tmux's own scrollback directly
+via `enkan-repl-tmux-mirror-history-lines'; tmux keeps the de-duplicated
+transcript for you.  Kept as an opt-in for backends that do scroll cleanly."
   :type 'boolean
   :group 'enkan-repl-terminal)
 
@@ -679,6 +696,18 @@ snapshot (legacy behavior)."
 This bounds how long `enkan-repl-tmux-refresh-current' can wait on a stuck
 tmux capture process."
   :type 'number
+  :group 'enkan-repl-terminal)
+
+(defcustom enkan-repl-tmux-history-limit 50000
+  "tmux `history-limit' (scrollback size) to apply for enkan panes.
+tmux fixes a pane's scrollback size when the pane is created (default 2000),
+so `tmux capture-pane -S -N' can never return more lines than the pane
+retained.  When non-nil, enkan sets this as the global tmux `history-limit'
+before creating a session/window so new enkan panes keep this many lines,
+letting `enkan-repl-tmux-mirror-history-lines' actually reach that far back.
+Existing (already-created) panes are not affected — restart them, or set
+`history-limit' in your tmux.conf.  Set to nil to leave tmux's value alone."
+  :type '(choice (const :tag "Leave tmux default" nil) integer)
   :group 'enkan-repl-terminal)
 
 (defcustom enkan-repl-tmux-disable-alternate-screen t

--- a/enkan-repl-terminal.el
+++ b/enkan-repl-terminal.el
@@ -659,6 +659,21 @@ process returns."
   :type 'integer
   :group 'enkan-repl-terminal)
 
+(defcustom enkan-repl-tmux-mirror-accumulate t
+  "When non-nil, accumulate tmux mirror content by appending new lines.
+Each `tmux capture-pane' returns only whatever tmux currently holds (its
+scrollback plus the visible viewport).  Full-screen AI CLIs (Claude Code,
+codex) redraw their conversation in place, so a single capture often exposes
+just a fraction of the chat history and the mirror would otherwise shrink to
+that viewport.  With accumulation on, each capture is merged into a growing
+transcript: the overlap between the accumulated tail and the new capture head
+is detected and only genuinely new lines are appended, so the mirror reliably
+keeps up to `enkan-repl-tmux-mirror-display-lines' lines of history regardless
+of tmux scrollback limits.  When nil, the mirror is replaced with each
+snapshot (legacy behavior)."
+  :type 'boolean
+  :group 'enkan-repl-terminal)
+
 (defcustom enkan-repl-tmux-mirror-capture-timeout 3.0
   "Seconds before an in-flight tmux mirror capture is cancelled.
 This bounds how long `enkan-repl-tmux-refresh-current' can wait on a stuck
@@ -704,6 +719,12 @@ the complete output."
 
 (defvar-local enkan-repl--tmux-mirror-last-content-hash nil
   "Buffer-local hash of the last captured tmux mirror content.")
+
+(defvar-local enkan-repl--tmux-mirror-accumulated nil
+  "Buffer-local accumulated tmux mirror transcript.
+Holds the growing merge of successive `tmux capture-pane' snapshots when
+`enkan-repl-tmux-mirror-accumulate' is non-nil.  Bounded to
+`enkan-repl-tmux-mirror-max-chars' characters (oldest content dropped).")
 
 (defvar enkan-repl--tmux-bell-monitor-timer nil
   "Timer used to poll tmux bell alerts for completion notifications.")
@@ -1261,6 +1282,62 @@ When MAX-CHARS is nil or non-positive, return the full concatenation."
          "\n"))
     content))
 
+(defun enkan-repl--terminal-tmux--bound-chars (content)
+  "Return CONTENT truncated to `enkan-repl-tmux-mirror-max-chars', keeping tail.
+When the limit is nil or non-positive, return CONTENT unchanged."
+  (let ((max-chars (and (integerp enkan-repl-tmux-mirror-max-chars)
+                        (> enkan-repl-tmux-mirror-max-chars 0)
+                        enkan-repl-tmux-mirror-max-chars)))
+    (if (and max-chars (> (length content) max-chars))
+        (substring content (- max-chars))
+      content)))
+
+(defun enkan-repl--terminal-tmux--strip-trailing-blank-lines (content)
+  "Return CONTENT with trailing blank (whitespace-only) lines removed.
+`tmux capture-pane' pads the viewport with blank lines up to the pane height;
+dropping them keeps the accumulated transcript clean and stabilizes overlap
+detection.  This is a pure function."
+  (let ((lines (split-string content "\n")))
+    (while (and (cdr lines)
+                (string-match-p "\\`[[:space:]]*\\'" (car (last lines))))
+      (setq lines (butlast lines)))
+    (when (and lines
+               (= (length lines) 1)
+               (string-match-p "\\`[[:space:]]*\\'" (car lines)))
+      (setq lines nil))
+    (string-join lines "\n")))
+
+(defun enkan-repl--terminal-tmux--merge-append (accumulated capture)
+  "Merge CAPTURE into the ACCUMULATED tmux transcript and return the result.
+CAPTURE is the latest `tmux capture-pane' snapshot; ACCUMULATED is the
+transcript kept so far (nil or empty on the first capture).  The longest
+overlap between the tail of ACCUMULATED and the head of CAPTURE is detected
+so a clean upward scroll appends only its genuinely new lines, giving a
+growing transcript instead of a viewport-sized snapshot.  When no overlap is
+found the whole capture is appended (simple fallback); when the capture is
+fully contained in the accumulated tail nothing is added.  This is a pure
+function."
+  (let ((capture (enkan-repl--terminal-tmux--strip-trailing-blank-lines
+                  (or capture ""))))
+    (cond
+     ((or (null accumulated) (string-empty-p accumulated)) capture)
+     ((string-empty-p capture) accumulated)
+     (t
+      (let* ((acc-lines (split-string accumulated "\n"))
+             (new-lines (split-string capture "\n"))
+             (max-k (min (length acc-lines) (length new-lines)))
+             (k 0)
+             (i max-k))
+        ;; Largest K such that the last K lines of ACCUMULATED equal the
+        ;; first K lines of CAPTURE (a clean upward scroll of the rest).
+        (while (and (> i 0) (= k 0))
+          (when (equal (last acc-lines i) (cl-subseq new-lines 0 i))
+            (setq k i))
+          (setq i (1- i)))
+        (if (= k (length new-lines))
+            accumulated
+          (string-join (append acc-lines (nthcdr k new-lines)) "\n")))))))
+
 (defun enkan-repl--terminal-tmux--prepare-mirror-content (content)
   "Return bounded, display-ready tmux mirror CONTENT."
   (let* ((max-chars (and (integerp enkan-repl-tmux-mirror-max-chars)
@@ -1353,12 +1430,20 @@ STARTED is the capture start time.  STATUS is the tmux process exit status."
          ((null content)
           (enkan-repl--terminal-tmux--mirror-mark-closed))
          (t
-          (let* ((content
-                  (enkan-repl--terminal-tmux--prepare-mirror-content content))
+          (let* ((merged
+                  (if enkan-repl-tmux-mirror-accumulate
+                      (enkan-repl--terminal-tmux--bound-chars
+                       (enkan-repl--terminal-tmux--merge-append
+                        enkan-repl--tmux-mirror-accumulated content))
+                    content))
+                 (content
+                  (enkan-repl--terminal-tmux--prepare-mirror-content merged))
                  (content-hash (secure-hash 'sha1 content))
                  (window-state (enkan-repl--terminal-tmux--mirror-window-state
                                 buffer))
                  (inhibit-read-only t))
+            (when enkan-repl-tmux-mirror-accumulate
+              (setq enkan-repl--tmux-mirror-accumulated merged))
             (setq enkan-repl--tmux-mirror-last-refresh-time (current-time))
             (setq enkan-repl--tmux-mirror-last-refresh-duration
                   (float-time

--- a/enkan-repl-utils.el
+++ b/enkan-repl-utils.el
@@ -748,13 +748,17 @@ This is a pure function."
 (defun enkan-repl--send-primitive (text special-key-type)
   "Pure function to prepare send content from TEXT and SPECIAL-KEY-TYPE.
 TEXT: original text content
-SPECIAL-KEY-TYPE: :enter, :escape, number 1-9, or nil
+SPECIAL-KEY-TYPE: :enter, :escape, :key-literal, number 1-9, or nil
+`:key-literal' sends TEXT verbatim as a key action (no trailing CR), used
+for control sequences such as clearing the input line.
 Returns plist with :content (string to send) and :action (action type)."
   (cond
    ((eq special-key-type :enter)
     (list :content "\r" :action 'key))
    ((eq special-key-type :escape)
     (list :content "\e" :action 'key))
+   ((eq special-key-type :key-literal)
+    (list :content text :action 'key))
    ((and (numberp special-key-type)
          (>= special-key-type 1)
          (<= special-key-type 9))

--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -1406,6 +1406,22 @@ Category: Text Sender"
   (interactive "P")
   (enkan-repl--send-unified "" pfx 5))
 
+;;;###autoload
+(defun enkan-repl-clear-input (&optional pfx)
+  "Clear the input field of the target enkan session buffer with optional PFX.
+Sends C-u (kill to beginning of line) to the target CLI so text mistakenly
+typed into the wrong workspace's input box can be removed without submitting
+it.  No Enter is sent.
+- From enkan buffer: Send to current buffer
+- From other buffer without prefix: Interactive buffer selection
+- With numeric prefix: Send to buffer at index (1-based)
+
+Uses unified backend with smart buffer detection.
+
+Category: Text Sender"
+  (interactive "P")
+  (enkan-repl--send-unified "\C-u" pfx :key-literal))
+
 
 ;;;###autoload
 (defun enkan-repl-recenter-bottom ()

--- a/examples/keybinding.el
+++ b/examples/keybinding.el
@@ -66,6 +66,7 @@ Requires magit to be installed."
        ("C-M-4"   . enkan-repl-send-4)
        ("C-M-5"   . enkan-repl-send-5)
        ("C-M-<return>" . enkan-repl-send-region)
+       ("C-M-c"   . enkan-repl-clear-input)
        ("C-M-@"   . enkan-repl-open-project-directory)
        ("C-t"     . other-window-or-split)
        ("C-M-b"   . enkan-repl-recenter-bottom)

--- a/test/enkan-repl-terminal-test.el
+++ b/test/enkan-repl-terminal-test.el
@@ -1000,5 +1000,58 @@ must be coerced to that string id."
     (should (string= "anything"
                      (enkan-repl--terminal--coerce-id "anything")))))
 
+(ert-deftest test-enkan-repl--terminal-tmux--strip-trailing-blank-lines ()
+  "Trailing blank lines are removed; interior blanks and content are kept."
+  (should (string= "a\nb"
+                   (enkan-repl--terminal-tmux--strip-trailing-blank-lines
+                    "a\nb\n\n   \n")))
+  (should (string= "a\n\nb"
+                   (enkan-repl--terminal-tmux--strip-trailing-blank-lines
+                    "a\n\nb")))
+  (should (string= ""
+                   (enkan-repl--terminal-tmux--strip-trailing-blank-lines
+                    "\n  \n"))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--merge-append-first-capture ()
+  "The first capture (nil/empty accumulator) becomes the transcript."
+  (should (string= "a\nb\nc"
+                   (enkan-repl--terminal-tmux--merge-append nil "a\nb\nc\n\n")))
+  (should (string= "a\nb\nc"
+                   (enkan-repl--terminal-tmux--merge-append "" "a\nb\nc"))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--merge-append-scroll ()
+  "A clean upward scroll appends only the genuinely new tail lines."
+  ;; Accumulated ends with the previous viewport [b c d]; the next capture
+  ;; [c d e f] overlaps on [c d] and contributes [e f].
+  (should (string= "a\nb\nc\nd\ne\nf"
+                   (enkan-repl--terminal-tmux--merge-append
+                    "a\nb\nc\nd" "c\nd\ne\nf"))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--merge-append-contained-noop ()
+  "A capture fully contained in the accumulated tail adds nothing."
+  (should (string= "a\nb\nc\nd"
+                   (enkan-repl--terminal-tmux--merge-append
+                    "a\nb\nc\nd" "c\nd")))
+  (should (string= "a\nb\nc\nd"
+                   (enkan-repl--terminal-tmux--merge-append
+                    "a\nb\nc\nd" "b\nc\nd"))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--merge-append-fresh-fallback ()
+  "With no overlap the whole capture is appended (simple fallback)."
+  (should (string= "a\nb\nx\ny"
+                   (enkan-repl--terminal-tmux--merge-append
+                    "a\nb" "x\ny"))))
+
+(ert-deftest test-enkan-repl--terminal-tmux--bound-chars ()
+  "Content longer than the limit keeps its tail; shorter content is intact."
+  (let ((enkan-repl-tmux-mirror-max-chars 4))
+    (should (string= "cdef"
+                     (enkan-repl--terminal-tmux--bound-chars "abcdef")))
+    (should (string= "ab"
+                     (enkan-repl--terminal-tmux--bound-chars "ab"))))
+  (let ((enkan-repl-tmux-mirror-max-chars 0))
+    (should (string= "abcdef"
+                     (enkan-repl--terminal-tmux--bound-chars "abcdef")))))
+
 (provide 'enkan-repl-terminal-test)
 ;;; enkan-repl-terminal-test.el ends here

--- a/test/enkan-repl-terminal-test.el
+++ b/test/enkan-repl-terminal-test.el
@@ -108,6 +108,45 @@ documented opt-in alternative; see README."
                         nil)
                       calls)))))
 
+(ert-deftest test-enkan-repl--terminal-tmux-start-applies-history-limit ()
+  "Starting a session should raise the global tmux history-limit first."
+  (let ((enkan-repl--current-workspace "01")
+        (enkan-repl-tmux-session-prefix "enkan-")
+        (enkan-repl-tmux-history-limit 50000)
+        calls)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--ensure-bell-monitor)
+               (lambda () nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--has-session)
+               (lambda (_session) nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--call)
+               (lambda (args &optional capture)
+                 (push (list args capture) calls)
+                 (when (member "new-session" args)
+                   "%12"))))
+      (enkan-repl--terminal-tmux-start "/repo/proj/")
+      (should (member '(("set-option" "-g" "history-limit" "50000") nil)
+                      calls)))))
+
+(ert-deftest test-enkan-repl--terminal-tmux-start-skips-history-limit-when-nil ()
+  "A nil history-limit should leave tmux untouched."
+  (let ((enkan-repl--current-workspace "01")
+        (enkan-repl-tmux-session-prefix "enkan-")
+        (enkan-repl-tmux-history-limit nil)
+        calls)
+    (cl-letf (((symbol-function 'enkan-repl--terminal-tmux--ensure-bell-monitor)
+               (lambda () nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--has-session)
+               (lambda (_session) nil))
+              ((symbol-function 'enkan-repl--terminal-tmux--call)
+               (lambda (args &optional capture)
+                 (push (list args capture) calls)
+                 (when (member "new-session" args)
+                   "%12"))))
+      (enkan-repl--terminal-tmux-start "/repo/proj/")
+      (should-not (cl-find "history-limit" calls
+                           :key (lambda (c) (nth 2 (car c)))
+                           :test #'equal)))))
+
 (ert-deftest test-enkan-repl--terminal-tmux-start-keeps-alternate-screen-when-off ()
   "Disabling the option should keep tmux alternate screen untouched."
   (let ((enkan-repl--current-workspace "01")
@@ -124,9 +163,10 @@ documented opt-in alternative; see README."
                  (when (member "new-session" args)
                    "%12"))))
       (enkan-repl--terminal-tmux-start "/repo/proj/")
-      (should-not (cl-find "set-option" calls
-                           :key (lambda (c) (car (car c)))
-                           :test #'equal)))))
+      ;; History-limit set-option may still be issued; only the alternate-screen
+      ;; option must be absent.
+      (should-not (cl-find "alternate-screen" calls
+                           :test (lambda (target call) (member target (car call))))))))
 
 (ert-deftest test-enkan-repl--terminal-tmux--capture-pane-async-targets-pane-id ()
   "Mirror capture for dr-remote.jp should pass %pane_id to tmux -t."
@@ -652,10 +692,13 @@ documented opt-in alternative; see README."
                     "abc" "def" nil))))
 
 (ert-deftest test-enkan-repl-tmux-mirror-default-limits ()
-  "Default tmux mirror limits should preserve useful proposal context."
-  (should (= 320 enkan-repl-tmux-mirror-history-lines))
-  (should (= 240 enkan-repl-tmux-mirror-display-lines))
-  (should (= (* 256 1024) enkan-repl-tmux-mirror-max-chars)))
+  "Default tmux mirror limits should expose a large real chat history."
+  (should (= 10000 enkan-repl-tmux-mirror-history-lines))
+  (should (= 10000 enkan-repl-tmux-mirror-display-lines))
+  (should (= (* 4 1024 1024) enkan-repl-tmux-mirror-max-chars))
+  ;; Append accumulation duplicates frames for in-place-redraw TUIs, so it is
+  ;; off by default; tmux scrollback is read directly instead.
+  (should-not enkan-repl-tmux-mirror-accumulate))
 
 (ert-deftest test-enkan-repl--terminal-tmux--prepare-mirror-content-keeps-proposal-defaults ()
   "Default mirror preparation should keep a moderate proposal from the start."

--- a/test/enkan-repl-utils-test.el
+++ b/test/enkan-repl-utils-test.el
@@ -205,6 +205,19 @@
       (when (file-exists-p test-file)
         (delete-file test-file)))))
 
+(ert-deftest test-enkan-repl--send-primitive-key-literal ()
+  "`:key-literal' sends TEXT verbatim as a key action (no trailing CR)."
+  (let ((result (enkan-repl--send-primitive "\C-u" :key-literal)))
+    (should (string= "\C-u" (plist-get result :content)))
+    (should (eq 'key (plist-get result :action)))))
+
+(ert-deftest test-enkan-repl--send-primitive-escape-and-enter ()
+  "Existing key types keep their content and key action."
+  (should (equal '(:content "\e" :action key)
+                 (enkan-repl--send-primitive "" :escape)))
+  (should (equal '(:content "\r" :action key)
+                 (enkan-repl--send-primitive "" :enter))))
+
 (provide 'enkan-repl-utils-test)
 
 ;;; enkan-repl-utils-test.el ends here


### PR DESCRIPTION
feat: improve tmux mirror chat-history capture and add clear-input (#75)

Reliably surface AI CLI chat history in the tmux mirror and add a command
to clear a pane's mis-typed input.

- Read tmux's own de-duplicated scrollback directly. Append accumulation is
  off by default because it duplicated frames for in-place-redraw TUIs.
- Raise the mirror history/display limits and add enkan-repl-tmux-history-limit
  so panes retain enough scrollback.
- Add enkan-repl-clear-input (bound to C-M-c), which sends C-u to clear the
  target pane's input line through the existing send target resolution.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
