### PR TITLE
feat: show TUI pane chat history from CLI transcripts (Claude Code)

### DIFF
--- a/enkan-repl-constants.el
+++ b/enkan-repl-constants.el
@@ -21,6 +21,7 @@
     ("enkan-repl-send-4" . "Send \\\\='4\\\\=' to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-send-5" . "Send \\\\='5\\\\=' to enkan session buffer with optional PFX. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
     ("enkan-repl-clear-input" . "Clear the input field of the target enkan session buffer with optional PFX. Sends C-u (kill to beginning of line) to the target CLI so text mistakenly typed into the wrong workspace's input box can be removed without submitting it.  No Enter is sent. - From enkan buffer: Send to current buffer - From other buffer without prefix: Interactive buffer selection - With numeric prefix: Send to buffer at index (1-based)  Uses unified backend with smart buffer detection.  Category: Text Sender")
+    ("enkan-repl-show-transcript" . "Show the AI CLI chat transcript for the target session's project. Full-screen CLIs (Claude Code, codex) redraw in place and keep no tmux scrollback, so this reads the CLI's own on-disk transcript for the target pane's working directory and shows it in a read-only buffer. - From enkan buffer: use the current buffer's session - Without prefix from elsewhere: interactive buffer selection - With numeric prefix PFX: use the session at that index (1-based)  Category: Utilities")
     ("enkan-repl-recenter-bottom" . "Recenter all enkan terminal buffers at bottom.  Category: Utilities")
     ("enkan-repl-open-project-input-file" . "Open or create project input file for DIRECTORY. If DIRECTORY is nil, use current `default-directory'. If project input file exists, open it directly. If not exists, create from template then open.  Category: Utilities")
     ("enkan-repl-start-session" . "Start a terminal session in the current directory. This is the backend-neutral session starter.  It works with both the eat and tmux terminal backends configured by `enkan-repl-terminal-backend'. FORCE is accepted for interactive compatibility and currently ignored; the command always starts a new session.  Category: Session Controller")
@@ -37,7 +38,7 @@
 Each element is a cons cell (FUNCTION-NAME . DESCRIPTION).")
 
 (defconst enkan-repl-cheat-sheet-function-count
-  22
+  23
   "Number of functions in cheat-sheet.")
 
 (provide 'enkan-repl-constants)

--- a/enkan-repl-transcript.el
+++ b/enkan-repl-transcript.el
@@ -1,0 +1,205 @@
+;;; enkan-repl-transcript.el --- Read AI CLI chat transcripts -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 phasetr
+
+;; Author: phasetr <phasetr@gmail.com>
+;; Keywords: convenience, tools
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Commentary:
+
+;; Full-screen AI CLIs (Claude Code, codex) redraw their viewport in place and
+;; do not push the conversation into tmux scrollback, so `tmux capture-pane'
+;; can only return the current screen.  Each CLI, however, writes its own
+;; conversation transcript to disk.  This module reads that transcript for a
+;; pane's working directory so the full chat history can be shown in Emacs,
+;; independent of tmux.
+;;
+;; Claude Code stores one JSONL file per session under
+;; `~/.claude/projects/NAME/', where NAME is the project's working directory
+;; with every non-alphanumeric character replaced by a hyphen.  Each line is a
+;; JSON event; `user' and `assistant' events carry the conversation.
+;;
+;; The pure parsing/formatting helpers are kept separate from the I/O and
+;; display helpers so they can be tested deterministically.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'subr-x)
+
+(declare-function enkan-repl--terminal-tmux--call "enkan-repl-terminal" (args &optional capture))
+(declare-function enkan-repl--terminal-tmux--target "enkan-repl-terminal" (id))
+
+(defgroup enkan-repl-transcript nil
+  "Reading AI CLI chat transcripts for enkan-repl."
+  :group 'enkan-repl)
+
+(defcustom enkan-repl-transcript-max-turns 400
+  "Maximum number of recent user/assistant turns to show in a transcript.
+When nil or non-positive, show the whole transcript."
+  :type '(choice (const :tag "All" nil) integer)
+  :group 'enkan-repl-transcript)
+
+(defcustom enkan-repl-claude-projects-directory "~/.claude/projects/"
+  "Directory where Claude Code stores per-project session transcripts."
+  :type 'directory
+  :group 'enkan-repl-transcript)
+
+;;;; Pure helpers
+
+(defun enkan-repl--transcript-encode-project-dir (cwd)
+  "Return the Claude Code project-directory name for absolute path CWD.
+Claude Code replaces every non-alphanumeric character of the working
+directory with a hyphen (for example \"/Users/me/dev/app\" becomes
+\"-Users-me-dev-app\").  This is a pure function."
+  (replace-regexp-in-string "[^A-Za-z0-9]" "-" cwd))
+
+(defun enkan-repl--transcript-role-marker (role)
+  "Return a short display marker for conversation ROLE.  Pure function."
+  (cond ((equal role "user") "▶")
+        ((equal role "assistant") "◀")
+        (t "•")))
+
+(defun enkan-repl--transcript-claude-extract-text (content)
+  "Return readable text from a Claude Code message CONTENT.
+CONTENT is either a string or a list of block alists; only `text' blocks
+contribute (thinking, tool calls, and tool results are dropped).  Returns a
+string, possibly empty.  This is a pure function."
+  (cond
+   ((stringp content) content)
+   ((listp content)
+    (mapconcat
+     (lambda (block)
+       (if (and (consp block)
+                (equal (alist-get 'type block) "text"))
+           (or (alist-get 'text block) "")
+         ""))
+     content ""))
+   (t "")))
+
+(defun enkan-repl--transcript-claude-parse-line (line)
+  "Parse a Claude Code transcript JSONL LINE into a (:role :text) plist.
+Return nil for blank lines, unparseable lines, non-conversation events,
+sidechain/meta entries, or entries whose extracted text is empty.  This is a
+pure function."
+  (when (and (stringp line) (not (string-empty-p (string-trim line))))
+    (let ((obj (ignore-errors
+                 (json-parse-string line
+                                    :object-type 'alist
+                                    :array-type 'list))))
+      (when (and obj (listp obj))
+        (let ((type (alist-get 'type obj))
+              (sidechain (alist-get 'isSidechain obj))
+              (meta (alist-get 'isMeta obj)))
+          (when (and (member type '("user" "assistant"))
+                     (not (eq sidechain t))
+                     (not (eq meta t)))
+            (let* ((message (alist-get 'message obj))
+                   (role (or (and (listp message) (alist-get 'role message))
+                             type))
+                   (text (string-trim
+                          (enkan-repl--transcript-claude-extract-text
+                           (and (listp message) (alist-get 'content message))))))
+              (unless (string-empty-p text)
+                (list :role role :text text)))))))))
+
+(defun enkan-repl--transcript-claude-format (lines &optional max-turns)
+  "Format Claude Code transcript LINES (a list of JSONL strings) into text.
+Keep only the last MAX-TURNS user/assistant turns when MAX-TURNS is a positive
+integer.  Each turn is rendered as a role-marked block.  This is a pure
+function."
+  (let* ((turns (delq nil (mapcar #'enkan-repl--transcript-claude-parse-line
+                                  lines)))
+         (turns (if (and (integerp max-turns) (> max-turns 0)
+                         (> (length turns) max-turns))
+                    (last turns max-turns)
+                  turns)))
+    (mapconcat
+     (lambda (turn)
+       (let ((role (plist-get turn :role)))
+         (format "%s %s\n%s"
+                 (enkan-repl--transcript-role-marker role)
+                 role
+                 (plist-get turn :text))))
+     turns "\n\n")))
+
+;;;; I/O helpers
+
+(defun enkan-repl--transcript-claude-dir (cwd)
+  "Return the Claude Code transcript directory for CWD, or nil when absent."
+  (let ((dir (expand-file-name
+              (enkan-repl--transcript-encode-project-dir
+               (directory-file-name (expand-file-name cwd)))
+              (expand-file-name enkan-repl-claude-projects-directory))))
+    (and (file-directory-p dir) dir)))
+
+(defun enkan-repl--transcript-claude-latest-file (cwd)
+  "Return the most recently modified Claude Code transcript file for CWD.
+Return nil when the project directory or any transcript is absent."
+  (let ((dir (enkan-repl--transcript-claude-dir cwd)))
+    (when dir
+      (car (sort (directory-files dir t "\\.jsonl\\'")
+                 (lambda (a b)
+                   (time-less-p (file-attribute-modification-time
+                                 (file-attributes b))
+                                (file-attribute-modification-time
+                                 (file-attributes a)))))))))
+
+(defun enkan-repl--transcript-file-lines (file)
+  "Return the non-empty lines of FILE as a list of strings, or nil."
+  (when (and file (file-readable-p file))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (split-string (buffer-string) "\n" t))))
+
+(defun enkan-repl--transcript-claude-load (cwd &optional max-turns)
+  "Return a plist (:file FILE :text TEXT) for CWD's Claude Code transcript.
+Return nil when no transcript exists.  MAX-TURNS bounds the number of turns."
+  (let ((file (enkan-repl--transcript-claude-latest-file cwd)))
+    (when file
+      (list :file file
+            :text (enkan-repl--transcript-claude-format
+                   (enkan-repl--transcript-file-lines file) max-turns)))))
+
+(defun enkan-repl--transcript-tmux-cwd (id)
+  "Return the working directory of tmux terminal ID, or nil."
+  (when (and id
+             (fboundp 'enkan-repl--terminal-tmux--call)
+             (fboundp 'enkan-repl--terminal-tmux--target))
+    (let ((out (enkan-repl--terminal-tmux--call
+                (list "display-message" "-p" "-t"
+                      (enkan-repl--terminal-tmux--target id)
+                      "#{pane_current_path}")
+                t)))
+      (when (and out (not (string-empty-p (string-trim out))))
+        (string-trim out)))))
+
+(defun enkan-repl--transcript-buffer-cwd (buffer)
+  "Return the working directory associated with terminal BUFFER, or nil."
+  (when (buffer-live-p buffer)
+    (or (enkan-repl--transcript-tmux-cwd
+         (buffer-local-value 'enkan-repl--tmux-mirror-id buffer))
+        (buffer-local-value 'default-directory buffer))))
+
+(defun enkan-repl--transcript-display (file text cwd)
+  "Show transcript TEXT read from FILE for project CWD in a dedicated buffer.
+Return the buffer."
+  (let ((buf (get-buffer-create
+              (format "*enkan-transcript: %s*"
+                      (file-name-nondirectory (directory-file-name cwd))))))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format "# transcript: %s\n# source: %s\n\n" cwd file))
+        (insert (or text ""))
+        (goto-char (point-max)))
+      (setq buffer-read-only t)
+      (setq-local default-directory (file-name-as-directory cwd)))
+    (display-buffer buf)
+    buf))
+
+(provide 'enkan-repl-transcript)
+
+;;; enkan-repl-transcript.el ends here

--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -76,6 +76,10 @@
               (unless noninteractive
                 (ignore-errors (enkan-repl-state-save))))))
 
+;; Load AI CLI transcript reader (Claude Code, codex)
+(when (locate-library "enkan-repl-transcript")
+  (require 'enkan-repl-transcript))
+
 ;; Load workspace management functions
 (when (locate-library "enkan-repl-workspace")
   (require 'enkan-repl-workspace))
@@ -146,6 +150,10 @@
 (declare-function enkan-repl--get-project-info-from-directories "enkan-repl-utils" (alias target-directories))
 (declare-function enkan-repl--get-project-path-from-directories "enkan-repl-utils" (project-name target-directories))
 (declare-function enkan-repl--send-primitive "enkan-repl-utils" (text special-key-type))
+(declare-function enkan-repl--transcript-buffer-cwd "enkan-repl-transcript" (buffer))
+(declare-function enkan-repl--transcript-claude-load "enkan-repl-transcript" (cwd &optional max-turns))
+(declare-function enkan-repl--transcript-display "enkan-repl-transcript" (file text cwd))
+(defvar enkan-repl-transcript-max-turns)
 (declare-function enkan-repl--buffer-name-matches-workspace "enkan-repl-utils" (name workspace-id))
 (declare-function enkan-repl--extract-workspace-id "enkan-repl-utils" (name))
 (declare-function enkan-repl-workspace-list--get-workspace-at-point
@@ -1421,6 +1429,61 @@ Uses unified backend with smart buffer detection.
 Category: Text Sender"
   (interactive "P")
   (enkan-repl--send-unified "\C-u" pfx :key-literal))
+
+(defun enkan-repl--pick-target-buffer (pfx prompt)
+  "Resolve a target enkan terminal buffer using PFX like the send commands.
+PROMPT labels the interactive selection.  Return the buffer, or nil when
+none is available or the selection is aborted."
+  (let* ((resolution (enkan-repl--resolve-send-target
+                      pfx nil
+                      (enkan-repl--ws-current-project)
+                      (enkan-repl--projects-with-current-aliases
+                       enkan-repl-projects
+                       (enkan-repl--ws-current-project)
+                       enkan-repl-project-aliases)
+                      enkan-repl-target-directories))
+         (status (plist-get resolution :status)))
+    (pcase status
+      ((or 'no-buffers 'invalid)
+       (message "%s" (plist-get resolution :message))
+       nil)
+      ((or 'selected 'single)
+       (plist-get resolution :buffer))
+      ('needs-selection
+       (let* ((buffers (plist-get resolution :buffers))
+              (choices (enkan-repl--build-buffer-selection-choices buffers))
+              (selection (hmenu prompt choices)))
+         (cdr (assoc selection choices)))))))
+
+;;;###autoload
+(defun enkan-repl-show-transcript (&optional pfx)
+  "Show the AI CLI chat transcript for the target session's project.
+Full-screen CLIs (Claude Code, codex) redraw in place and keep no tmux
+scrollback, so this reads the CLI's own on-disk transcript for the target
+pane's working directory and shows it in a read-only buffer.
+- From enkan buffer: use the current buffer's session
+- Without prefix from elsewhere: interactive buffer selection
+- With numeric prefix PFX: use the session at that index (1-based)
+
+Category: Utilities"
+  (interactive "P")
+  (let ((buffer (enkan-repl--pick-target-buffer
+                 pfx "Select buffer for transcript:")))
+    (when buffer
+      (let ((cwd (enkan-repl--transcript-buffer-cwd buffer)))
+        (cond
+         ((not cwd)
+          (message "Could not determine working directory for %s"
+                   (buffer-name buffer)))
+         (t
+          (let ((result (enkan-repl--transcript-claude-load
+                         cwd enkan-repl-transcript-max-turns)))
+            (if (null result)
+                (message "No Claude Code transcript found for %s" cwd)
+              (enkan-repl--transcript-display
+               (plist-get result :file)
+               (plist-get result :text)
+               cwd)))))))))
 
 
 ;;;###autoload

--- a/test/enkan-repl-transcript-test.el
+++ b/test/enkan-repl-transcript-test.el
@@ -1,0 +1,103 @@
+;;; enkan-repl-transcript-test.el --- Tests for transcript reader -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Tests for the pure parsing/formatting helpers of `enkan-repl-transcript'.
+;; I/O and display helpers require real files/tmux and are exercised manually.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+
+(let ((project-root (file-name-directory (directory-file-name (file-name-directory (or load-file-name buffer-file-name))))))
+  (add-to-list 'load-path project-root))
+
+(require 'enkan-repl-transcript)
+
+;;;; project-dir encoding
+
+(ert-deftest test-enkan-repl--transcript-encode-project-dir ()
+  "Every non-alphanumeric character becomes a hyphen; hyphens are kept."
+  (should (string= "-Users-sekine-dev-self-lattice-system"
+                   (enkan-repl--transcript-encode-project-dir
+                    "/Users/sekine/dev/self/lattice-system")))
+  ;; Dotted components collapse each dot to a hyphen (so /.emacs.d -> --emacs-d).
+  (should (string= "-Users-sekine--emacs-d"
+                   (enkan-repl--transcript-encode-project-dir
+                    "/Users/sekine/.emacs.d"))))
+
+;;;; role markers
+
+(ert-deftest test-enkan-repl--transcript-role-marker ()
+  (should (string= "▶" (enkan-repl--transcript-role-marker "user")))
+  (should (string= "◀" (enkan-repl--transcript-role-marker "assistant")))
+  (should (string= "•" (enkan-repl--transcript-role-marker "system"))))
+
+;;;; content text extraction
+
+(ert-deftest test-enkan-repl--transcript-claude-extract-text-string ()
+  "A plain string content is returned as-is."
+  (should (string= "hello"
+                   (enkan-repl--transcript-claude-extract-text "hello"))))
+
+(ert-deftest test-enkan-repl--transcript-claude-extract-text-blocks ()
+  "Only text blocks contribute; thinking/tool blocks are dropped."
+  (let ((content (list '((type . "thinking") (thinking . "hmm"))
+                       '((type . "text") (text . "first"))
+                       '((type . "tool_use") (name . "Bash"))
+                       '((type . "text") (text . "second")))))
+    (should (string= "firstsecond"
+                     (enkan-repl--transcript-claude-extract-text content)))))
+
+;;;; JSONL line parsing
+
+(ert-deftest test-enkan-repl--transcript-claude-parse-line-user ()
+  "A user line with string content yields a user turn."
+  (let ((line "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi there\"}}"))
+    (should (equal '(:role "user" :text "hi there")
+                   (enkan-repl--transcript-claude-parse-line line)))))
+
+(ert-deftest test-enkan-repl--transcript-claude-parse-line-assistant ()
+  "An assistant line with text blocks yields an assistant turn."
+  (let ((line "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"x\"},{\"type\":\"text\",\"text\":\"answer\"}]}}"))
+    (should (equal '(:role "assistant" :text "answer")
+                   (enkan-repl--transcript-claude-parse-line line)))))
+
+(ert-deftest test-enkan-repl--transcript-claude-parse-line-skips ()
+  "Blank, unparseable, non-conversation, sidechain, meta, and empty-text
+lines are skipped."
+  (should-not (enkan-repl--transcript-claude-parse-line ""))
+  (should-not (enkan-repl--transcript-claude-parse-line "   "))
+  (should-not (enkan-repl--transcript-claude-parse-line "{not json"))
+  (should-not (enkan-repl--transcript-claude-parse-line
+               "{\"type\":\"system\",\"message\":{\"role\":\"system\",\"content\":\"x\"}}"))
+  (should-not (enkan-repl--transcript-claude-parse-line
+               "{\"type\":\"user\",\"isSidechain\":true,\"message\":{\"role\":\"user\",\"content\":\"sub\"}}"))
+  (should-not (enkan-repl--transcript-claude-parse-line
+               "{\"type\":\"assistant\",\"isMeta\":true,\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"m\"}]}}"))
+  (should-not (enkan-repl--transcript-claude-parse-line
+               "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"only\"}]}}")))
+
+;;;; formatting
+
+(ert-deftest test-enkan-repl--transcript-claude-format-orders-and-marks ()
+  "Formatting renders each turn with its role marker in order."
+  (let ((lines (list
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"q1\"}}"
+                "garbage"
+                "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"a1\"}]}}")))
+    (should (string= "▶ user\nq1\n\n◀ assistant\na1"
+                     (enkan-repl--transcript-claude-format lines)))))
+
+(ert-deftest test-enkan-repl--transcript-claude-format-max-turns ()
+  "MAX-TURNS keeps only the most recent turns."
+  (let ((lines (list
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"q1\"}}"
+                "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"a1\"}]}}"
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"q2\"}}")))
+    (should (string= "▶ user\nq2"
+                     (enkan-repl--transcript-claude-format lines 1)))))
+
+(provide 'enkan-repl-transcript-test)
+
+;;; enkan-repl-transcript-test.el ends here


### PR DESCRIPTION
feat: show TUI pane chat history from CLI transcripts (Claude Code) (#76)

Full-screen CLIs redraw in place and keep no tmux scrollback, so read the
CLI's own on-disk transcript instead. Add enkan-repl-transcript.el, which
maps a pane's cwd to ~/.claude/projects/<encoded>/ and formats the latest
session JSONL (user/assistant turns, dropping thinking/tool/sidechain/meta
noise). enkan-repl-show-transcript resolves the target pane like the send
commands and shows the history in a read-only buffer.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
