### PR TITLE
docs: add example keybinding for workspace-renumber (C-M-n)

### DIFF
--- a/examples/keybinding.el
+++ b/examples/keybinding.el
@@ -75,6 +75,7 @@ Requires magit to be installed."
        ("C-M-s"   . enkan-repl-setup)
        ("C-M-t"   . enkan-repl-workspace-delete)
        ("C-M-w"   . enkan-repl-workspace-switch)
+       ("C-M-n"   . enkan-repl-workspace-renumber)
        ("C-M-g" . enkan-repl-tmux-refresh-workspace)
        ("C-M-r" . enkan-repl-tmux-reattach)
        ("C-M-l"   . enkan-repl-setup-current-project-layout))))


### PR DESCRIPTION
## Summary
- `examples/keybinding.el` に `enkan-repl-workspace-renumber` 用の `C-M-n` バインドを追加。
- 既存の workspace 系コマンド (`C-M-t` delete, `C-M-w` switch) と並ぶ配置。

## Test plan
- example ファイルのみの変更のため `make check` は対象外 (examples はロード対象外)。